### PR TITLE
Sorting currencies for the base currency selection, issue #28.

### DIFF
--- a/src/com/money/manager/ex/settings/GeneralSettingsActivity.java
+++ b/src/com/money/manager/ex/settings/GeneralSettingsActivity.java
@@ -34,10 +34,12 @@ import com.money.manager.ex.core.Core;
 import com.money.manager.ex.database.TableCurrencyFormats;
 import com.money.manager.ex.fragment.BaseFragmentActivity;
 import com.money.manager.ex.preferences.PreferencesConstant;
+import com.money.manager.ex.utils.CurrencyNameComparator;
 import com.money.manager.ex.utils.CurrencyUtils;
 
 import org.apache.commons.lang3.math.NumberUtils;
 
+import java.util.Collections;
 import java.util.List;
 
 public class GeneralSettingsActivity extends BaseFragmentActivity {
@@ -118,6 +120,9 @@ public class GeneralSettingsActivity extends BaseFragmentActivity {
             final ListPreference lstBaseCurrency = (ListPreference) findPreference(getString(PreferencesConstant.PREF_BASE_CURRENCY));
             if (lstBaseCurrency != null) {
                 List<TableCurrencyFormats> currencies = currencyUtils.getAllCurrencyFormats();
+                // sort the currencies by name.
+                Collections.sort(currencies, new CurrencyNameComparator());
+
                 String[] entries = new String[currencies.size()];
                 String[] entryValues = new String[currencies.size()];
                 // list of currency

--- a/src/com/money/manager/ex/utils/CurrencyNameComparator.java
+++ b/src/com/money/manager/ex/utils/CurrencyNameComparator.java
@@ -1,0 +1,16 @@
+package com.money.manager.ex.utils;
+
+import com.money.manager.ex.database.TableCurrencyFormats;
+
+import java.util.Comparator;
+
+/**
+ * Compare two Currencies by Name.
+ * Created by Alen Siljak on 11/03/2015.
+ */
+public class CurrencyNameComparator implements Comparator<TableCurrencyFormats> {
+    @Override
+    public int compare(TableCurrencyFormats o1, TableCurrencyFormats o2) {
+        return o1.getCurrencyName().compareTo(o2.getCurrencyName());
+    }
+}


### PR DESCRIPTION
I have a solution here for sorting the currencies for the base currency selection view. They are now sorted by name, which is the only shown piece of information, so should make it easier to select a desired currency.

Still not sure if it is possible to link an existing issue to the new pull request. In any case, the issue for this fix is #28.