### PR TITLE
using "Due Today" instead of "Inactive" when a recurring transaction is ...

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -521,4 +521,5 @@
     <string name="invalid_expression">Invalid expression</string>
     <string name="send_me_logcat">Logcat</string>
     <string name="dropbox_database_can_be_updted">There is an update of the database on Dropbox</string>
+    <string name="due_today">Due Today</string>
 </resources>

--- a/src/com/money/manager/ex/adapter/RepeatingTransactionAdapter.java
+++ b/src/com/money/manager/ex/adapter/RepeatingTransactionAdapter.java
@@ -86,7 +86,7 @@ public class RepeatingTransactionAdapter extends CursorAdapter {
         // take daysleft
         int daysLeft = cursor.getInt(cursor.getColumnIndex(QueryBillDeposits.DAYSLEFT));
         if (daysLeft == 0) {
-            txtNextDueDate.setText(R.string.inactive);
+            txtNextDueDate.setText(R.string.due_today);
         } else {
             txtNextDueDate.setText(Integer.toString(Math.abs(daysLeft)) + " " + context.getString(daysLeft > 0 ? R.string.days_remaining : R.string.days_overdue));
             imgClock.setVisibility(daysLeft < 0 ? View.VISIBLE : View.INVISIBLE);


### PR DESCRIPTION
fix for #41 
The text now says "Due Today" instead of "Inactive" when the transaction is due on the current day.