### PR TITLE
Small improvements for faster use of the application

### DIFF
--- a/res/menu/menu_payee.xml
+++ b/res/menu/menu_payee.xml
@@ -24,5 +24,16 @@
         android:id="@+id/menu_sort"
         android:icon="@drawable/ic_action_sort_dark"
         android:title="@string/sort"
-        app:showAsAction="always"/>
+        app:showAsAction="always">
+        <menu>
+            <group android:checkableBehavior="single">
+                <item
+                    android:id="@+id/menu_sort_name"
+                    android:title="@string/sort_by_name"/>
+                <item
+                    android:id="@+id/menu_sort_usage"
+                    android:title="@string/sort_by_usage"/>
+            </group>
+        </menu>
+    </item>
 </menu>

--- a/src/com/money/manager/ex/AccountListActivity.java
+++ b/src/com/money/manager/ex/AccountListActivity.java
@@ -321,5 +321,13 @@ public class AccountListActivity extends BaseFragmentActivity {
         public void onFloatingActionButtonClickListener() {
             startAccountListEditActivity();
         }
+
+        @Override
+        public void onListItemClick(ListView l, View v, int position, long id) {
+            super.onListItemClick(l, v, position, id);
+
+            // show context menu here.
+            getActivity().openContextMenu(v);
+        }
     }
 }

--- a/src/com/money/manager/ex/MainActivity.java
+++ b/src/com/money/manager/ex/MainActivity.java
@@ -812,7 +812,7 @@ public class MainActivity extends BaseFragmentActivity {
         // donate
         adapter.add(new DrawerMenuItem().withId(R.id.menu_donate)
                 .withText(getString(R.string.donate))
-                .withIcon(isDarkTheme ? R.drawable.ic_action_reports_dark : R.drawable.ic_action_redeem_light)
+                .withIcon(isDarkTheme ? R.drawable.ic_action_redeem_dark : R.drawable.ic_action_redeem_light)
                 .withDivider(Boolean.TRUE));
         // help
         adapter.add(new DrawerMenuItem().withId(R.id.menu_about)

--- a/src/com/money/manager/ex/PayeeActivity.java
+++ b/src/com/money/manager/ex/PayeeActivity.java
@@ -144,26 +144,36 @@ public class PayeeActivity extends BaseFragmentActivity {
         public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
             super.onCreateOptionsMenu(menu, inflater);
             inflater.inflate(R.menu.menu_payee, menu);
+            //Check the default sort order
+            final MenuItem item;
+            switch (PreferenceManager.getDefaultSharedPreferences(getActivity()).getInt(getString(PreferencesConstant.PREF_SORT_PAYEE), 0)) {
+                case 0 :
+                    item = menu.findItem(R.id.menu_sort_name);
+                    item.setChecked(true);
+                    break;
+                case 1 :
+                    item = menu.findItem(R.id.menu_sort_usage);
+                    item.setChecked(true);
+                    break;
+            }
         }
 
         @Override
         public boolean onOptionsItemSelected(MenuItem item) {
             switch (item.getItemId()) {
-                case R.id.menu_sort:
-                    new MaterialDialog.Builder(getActivity())
-                            .title(R.string.choose_sorting)
-                            .items(R.array.choose_payee_sort)
-                            .itemsCallbackSingleChoice(mSort, new MaterialDialog.ListCallback() {
-                                @Override
-                                public void onSelection(MaterialDialog dialog, View view, int which, CharSequence text) {
-                                    mSort = which;
-                                    PreferenceManager.getDefaultSharedPreferences(getActivity()).edit().putInt(getString(PreferencesConstant.PREF_SORT_PAYEE), mSort).commit();
-                                    // restart search
-                                    restartLoader();
-                                }
-                            })
-                            .positiveText(android.R.string.ok)
-                            .show();
+                case R.id.menu_sort_name:
+                    mSort= 0;
+                    item.setChecked(true);
+                    PreferenceManager.getDefaultSharedPreferences(getActivity()).edit().putInt(getString(PreferencesConstant.PREF_SORT_PAYEE), mSort).commit();
+                    // restart search
+                    restartLoader();
+                    return true;
+                case R.id.menu_sort_usage:
+                    mSort = 1;
+                    item.setChecked(true);
+                    PreferenceManager.getDefaultSharedPreferences(getActivity()).edit().putInt(getString(PreferencesConstant.PREF_SORT_PAYEE), mSort).commit();
+                    // restart search
+                    restartLoader();
                     return true;
             }
             return super.onOptionsItemSelected(item);

--- a/src/com/money/manager/ex/PayeeActivity.java
+++ b/src/com/money/manager/ex/PayeeActivity.java
@@ -399,5 +399,15 @@ public class PayeeActivity extends BaseFragmentActivity {
         public void restartLoader() {
             getLoaderManager().restartLoader(ID_LOADER_PAYEE, null, this);
         }
+
+        @Override
+        public void onListItemClick(ListView l, View v, int position, long id) {
+            super.onListItemClick(l, v, position, id);
+
+            // On select go back to the calling activity (if there is one)
+            if (getActivity().getCallingActivity() != null){
+                setResultAndFinish();
+            }
+        }
     }
 }


### PR DESCRIPTION
Hi,

Here are some small changes I made for faster use of the application :
- On the account list page : show the context menu with a single tap (before there was no action for single tap);
- On the payee page : use a small menu to change sorting instead of a dialog menu (less click and closer on a big screen like a tablet)
![screenshot_2015-03-28-13-40-46](https://cloud.githubusercontent.com/assets/2464288/6881076/764378d0-d550-11e4-8bab-0cd119f9d44e.png)
(Only problem, the <a href="https://github.com/moneymanagerex/android-money-manager-ex/issues/75">issue 75</a> is also present on this overflow menu);
- Correcting the donate icon with the material dark theme.