### PR TITLE
Fixes force close problem in "Help" of dropbox settings

### DIFF
--- a/res/layout/webview_activity.xml
+++ b/res/layout/webview_activity.xml
@@ -4,6 +4,9 @@
     android:layout_height="match_parent"
     android:orientation="vertical" >
 
+    <!-- Navigation Drawer -->
+    <include layout="@layout/toolbar"/>
+
     <WebView
         android:id="@+id/webViewContent"
         android:layout_width="match_parent"


### PR DESCRIPTION
There was no toolbar on this page causing the problem when trying to call setDisplayHomeAsUpEnabled on the toolbar.