### PR TITLE
Currencies, no context menu

### DIFF
--- a/src/com/money/manager/ex/AccountListEditActivity.java
+++ b/src/com/money/manager/ex/AccountListEditActivity.java
@@ -161,7 +161,7 @@ public class AccountListEditActivity extends BaseFragmentActivity implements Inp
         if (mCurrencyId == null) {
             CurrencyUtils currencyUtils = new CurrencyUtils(getApplicationContext());
 
-            TableCurrencyFormats currencyFormats = currencyUtils.getTableCurrencyFormats(currencyUtils.getBaseCurrencyId());
+            TableCurrencyFormats currencyFormats = currencyUtils.getCurrency(currencyUtils.getBaseCurrencyId());
 
             if (currencyFormats != null) {
                 mCurrencyId = currencyFormats.getCurrencyId();

--- a/src/com/money/manager/ex/CurrencyFormatsListActivity.java
+++ b/src/com/money/manager/ex/CurrencyFormatsListActivity.java
@@ -84,6 +84,7 @@ public class CurrencyFormatsListActivity extends BaseFragmentActivity {
         // take intent
         Intent intent = getIntent();
         if (intent != null && !(TextUtils.isEmpty(intent.getAction()))) {
+            // Store the requested action.
             mAction = intent.getAction();
         }
 
@@ -105,7 +106,8 @@ public class CurrencyFormatsListActivity extends BaseFragmentActivity {
         return super.onKeyUp(keyCode, event);
     }
 
-    public static class CurrencyFormatsLoaderListFragment extends BaseListFragment implements LoaderManager.LoaderCallbacks<Cursor> {
+    public static class CurrencyFormatsLoaderListFragment extends BaseListFragment
+            implements LoaderManager.LoaderCallbacks<Cursor> {
         // filter
         private String mCurFilter;
         private int mLayout;
@@ -119,7 +121,10 @@ public class CurrencyFormatsListActivity extends BaseFragmentActivity {
             setEmptyText(getActivity().getResources().getString(R.string.account_empty_list));
             setHasOptionsMenu(true);
 
-            mLayout = Intent.ACTION_PICK.equals(mAction) ? android.R.layout.simple_list_item_multiple_choice : android.R.layout.simple_list_item_1;
+            mLayout = Intent.ACTION_PICK.equals(mAction)
+                    ? android.R.layout.simple_list_item_multiple_choice
+                    : android.R.layout.simple_list_item_1;
+
             // associate adapter
             MoneySimpleCursorAdapter adapter = new MoneySimpleCursorAdapter(getActivity(), mLayout, null, new String[]{TableCurrencyFormats.CURRENCYNAME},
                     new int[]{android.R.id.text1}, 0);
@@ -498,8 +503,9 @@ public class CurrencyFormatsListActivity extends BaseFragmentActivity {
         public void onListItemClick(ListView l, View v, int position, long id) {
             super.onListItemClick(l, v, position, id);
 
-            // todo: show context menu if we are displaying the list of currencies (not in selection mode).
-            getActivity().openContextMenu(v);
+            // Show context menu only if we are displaying the list of currencies
+            // but not in selection mode.
+            if(mAction.equals(Intent.ACTION_EDIT)) getActivity().openContextMenu(v);
         }
     }
 }

--- a/src/com/money/manager/ex/CurrencyFormatsListActivity.java
+++ b/src/com/money/manager/ex/CurrencyFormatsListActivity.java
@@ -498,7 +498,7 @@ public class CurrencyFormatsListActivity extends BaseFragmentActivity {
         public void onListItemClick(ListView l, View v, int position, long id) {
             super.onListItemClick(l, v, position, id);
 
-            // show context menu here.
+            // todo: show context menu if we are displaying the list of currencies (not in selection mode).
             getActivity().openContextMenu(v);
         }
     }

--- a/src/com/money/manager/ex/MainActivity.java
+++ b/src/com/money/manager/ex/MainActivity.java
@@ -56,7 +56,6 @@ import com.afollestad.materialdialogs.AlertDialogWrapper;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.money.manager.ex.AccountListActivity.AccountLoaderListFragment;
 import com.money.manager.ex.CategorySubCategoryExpandableListActivity.CategorySubCategoryExpandableLoaderListFragment;
-import com.money.manager.ex.CurrencyFormatsListActivity.CurrencyFormatsLoaderListFragment;
 import com.money.manager.ex.PayeeActivity.PayeeLoaderListFragment;
 import com.money.manager.ex.RepeatingTransactionListActivity.RepeatingTransactionListFragment;
 import com.money.manager.ex.about.AboutActivity;
@@ -872,7 +871,12 @@ public class MainActivity extends BaseFragmentActivity {
             showFragment(CategorySubCategoryExpandableLoaderListFragment.class);
             return true;
         } else if (item.getId() == R.id.menu_currency) {
-            showFragment(CurrencyFormatsLoaderListFragment.class);
+            // Show Currency list.
+
+            intent = new Intent(MainActivity.this, CurrencyFormatsListActivity.class);
+            intent.setAction(Intent.ACTION_EDIT);
+            startActivity(intent);
+
             return true;
         } else if (item.getId() == R.id.menu_payee) {
             showFragment(PayeeLoaderListFragment.class);

--- a/src/com/money/manager/ex/settings/GeneralSettingsActivity.java
+++ b/src/com/money/manager/ex/settings/GeneralSettingsActivity.java
@@ -19,7 +19,6 @@
 package com.money.manager.ex.settings;
 
 import android.os.Bundle;
-import android.preference.CheckBoxPreference;
 import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
@@ -55,6 +54,7 @@ public class GeneralSettingsActivity extends BaseSettingsFragmentActivity {
         @Override
         public void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
+
             addPreferencesFromResource(R.xml.general_settings);
             PreferenceManager.getDefaultSharedPreferences(getActivity());
 
@@ -131,7 +131,7 @@ public class GeneralSettingsActivity extends BaseSettingsFragmentActivity {
                 // set value
                 lstBaseCurrency.setEntries(entries);
                 lstBaseCurrency.setEntryValues(entryValues);
-                TableCurrencyFormats tableCurrency = currencyUtils.getTableCurrencyFormats(currencyUtils.getBaseCurrencyId());
+                TableCurrencyFormats tableCurrency = currencyUtils.getCurrency(currencyUtils.getBaseCurrencyId());
                 if (tableCurrency != null) {
                     lstBaseCurrency.setSummary(tableCurrency.getCurrencyName());
                 }
@@ -140,7 +140,7 @@ public class GeneralSettingsActivity extends BaseSettingsFragmentActivity {
                     public boolean onPreferenceChange(Preference preference, Object newValue) {
                         if (currencyUtils.setBaseCurrencyId(Integer.valueOf(String.valueOf(newValue)))) {
                             currencyUtils.reInit();
-                            TableCurrencyFormats tableCurrency = currencyUtils.getTableCurrencyFormats(currencyUtils.getBaseCurrencyId());
+                            TableCurrencyFormats tableCurrency = currencyUtils.getCurrency(currencyUtils.getBaseCurrencyId());
                             if (tableCurrency != null) {
                                 lstBaseCurrency.setSummary(tableCurrency.getCurrencyName());
                             }

--- a/src/com/money/manager/ex/utils/CurrencyUtils.java
+++ b/src/com/money/manager/ex/utils/CurrencyUtils.java
@@ -124,8 +124,8 @@ public class CurrencyUtils {
     }
 
     public Double doCurrencyExchange(Integer toCurrencyId, double toAmount, Integer fromCurrencyId) {
-        TableCurrencyFormats fromCurrencyFormats = getTableCurrencyFormats(fromCurrencyId);
-        TableCurrencyFormats toCurrencyFormats = getTableCurrencyFormats(toCurrencyId);
+        TableCurrencyFormats fromCurrencyFormats = getCurrency(fromCurrencyId);
+        TableCurrencyFormats toCurrencyFormats = getCurrency(toCurrencyId);
         // check if exists from and to currencies
         if (fromCurrencyFormats == null || toCurrencyFormats == null)
             return null;
@@ -138,8 +138,8 @@ public class CurrencyUtils {
     }
 
     public boolean updateCurrencyRate(Integer fromCurrencyId, Integer toCurrencyId) {
-        TableCurrencyFormats fromCurrencyFormats = getTableCurrencyFormats(fromCurrencyId);
-        TableCurrencyFormats toCurrencyFormats = getTableCurrencyFormats(toCurrencyId);
+        TableCurrencyFormats fromCurrencyFormats = getCurrency(fromCurrencyId);
+        TableCurrencyFormats toCurrencyFormats = getCurrency(toCurrencyId);
         // check if exists from and to currencies
         if (fromCurrencyFormats == null || toCurrencyFormats == null)
             return false;
@@ -249,7 +249,7 @@ public class CurrencyUtils {
 
         // find currencyid
         if (currencyId != null) {
-            TableCurrencyFormats tableCurrency = getTableCurrencyFormats(currencyId);
+            TableCurrencyFormats tableCurrency = getCurrency(currencyId);
 
             if (tableCurrency == null) {
                 return String.valueOf(value);
@@ -274,7 +274,7 @@ public class CurrencyUtils {
 
         // find currencyid
         if (currencyId != null) {
-            TableCurrencyFormats tableCurrency = getTableCurrencyFormats(currencyId);
+            TableCurrencyFormats tableCurrency = getCurrency(currencyId);
 
             if (tableCurrency == null) {
                 return String.valueOf(value);
@@ -290,7 +290,7 @@ public class CurrencyUtils {
      * @param currencyId of the currency to be get
      * @return an instance of class TableCurrencyFormats. Null if fail
      */
-    public TableCurrencyFormats getTableCurrencyFormats(Integer currencyId) {
+    public TableCurrencyFormats getCurrency(Integer currencyId) {
         if (mCurrencies != null && currencyId != null) {
             return mCurrencies.get(currencyId);
         } else {


### PR DESCRIPTION
The look & behaviour of the Currency list now depends on the action requested.
In Edit mode, there are no selection checkboxes and the context menu is displayed only on long tap.
In Pick mode, there are selection checkboxes and NO context menu on single tap.
Implements #92.