### PR TITLE
Allow to configure transactions sorting.

### DIFF
--- a/app/src/main/java/com/money/manager/ex/account/AccountTransactionListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/account/AccountTransactionListFragment.java
@@ -121,6 +121,8 @@ public class AccountTransactionListFragment
     // filter
     private TransactionFilter mFilter;
 
+    private boolean mSortTransactionsByType = true;
+
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
@@ -204,6 +206,8 @@ public class AccountTransactionListFragment
     @Override
     public void onResume() {
         super.onResume();
+
+        refreshSettings();
 
         initializeAccountsSelector();
         selectCurrentAccount();
@@ -669,12 +673,16 @@ public class AccountTransactionListFragment
         where.addStatement(QueryAllData.Status, "IN", mFilter.transactionStatus.getSqlParameters());
 
         // create a bundle to returns
+
+        String sortArgument = QueryAllData.Date + " DESC, ";
+        if (mSortTransactionsByType) {
+            sortArgument += QueryAllData.TransactionType + ", ";
+        }
+        sortArgument += QueryAllData.ID + " DESC";
+
         Bundle args = new Bundle();
         args.putString(AllDataListFragment.KEY_ARGUMENTS_WHERE, where.getWhere());
-        args.putString(AllDataListFragment.KEY_ARGUMENTS_SORT,
-            QueryAllData.Date + " DESC, " +
-                QueryAllData.TransactionType + ", " +
-                QueryAllData.ID + " DESC");
+        args.putString(AllDataListFragment.KEY_ARGUMENTS_SORT, sortArgument);
 
         return args;
     }
@@ -865,4 +873,7 @@ public class AccountTransactionListFragment
         this.startCheckingAccountActivity(null);
     }
 
+    private void refreshSettings() {
+        mSortTransactionsByType = new AppSettings(getActivity()).getLookAndFeelSettings().getSortTransactionsByType();
+    }
 }

--- a/app/src/main/java/com/money/manager/ex/settings/LookAndFeelSettings.java
+++ b/app/src/main/java/com/money/manager/ex/settings/LookAndFeelSettings.java
@@ -116,4 +116,8 @@ public class LookAndFeelSettings
         infoService.setInfoValue(InfoKeys.SHOW_FAVOURITE_ACCOUNTS, value.toString());
     }
 
+    public boolean getSortTransactionsByType() {
+        String key = getSettingsKey(R.string.pref_transaction_sort_by_type);
+        return getBooleanSetting(key, true);
+    }
 }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -464,6 +464,8 @@
   <string name="custom_dates">Настраиваемые даты</string>
   <string name="pref_transaction_hide_reconciled_amounts_summary">Скрыть подтвержденные суммы со счетов на основной панели.</string>
   <string name="pref_transaction_hide_reconciled_amounts_title">Скрыть подтвержденные суммы</string>
+  <string name="pref_transaction_sort_by_type_title">Сортировать транзакции по типу</string>
+  <string name="pref_transaction_sort_by_type_summary">Сортировать транзакции за день по типу (пополнение, перевод, снятие)</string>
   <string name="warning">Предупреждение</string>
   <string name="no_transfer_splits">Вы выбрали операцию перевода между счетами вместо текущей операции, но в текущей транзакции присутствуют разделенные [Split] категории. Вы хотите продолжить и удалить разделенные [Split] категории ?</string>
   <string name="qif_export">QIF экспорт</string>

--- a/app/src/main/res/values/prefids.xml
+++ b/app/src/main/res/values/prefids.xml
@@ -61,6 +61,7 @@
     <string name="pref_transaction_hide_reconciled_amounts">pref_transaction_hide_reconciled_amounts</string>
     <string name="pref_application_font">prefapplicationfont</string>
     <string name="pref_application_font_size">prefapplicationfontsize</string>
+    <string name="pref_transaction_sort_by_type">pref_transaction_sort_by_type</string>
     <string name="pref_dropbox_wiki">prefdropboxwiki</string>
     <string name="pref_default_status">prefdefaultstatus</string>
     <string name="pref_default_payee">prefdefaultpayee</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -516,6 +516,8 @@
     <string name="custom_dates">Custom Dates</string>
     <string name="pref_transaction_hide_reconciled_amounts_summary">Hide the reconciled amounts from the accounts on dashboard.</string>
     <string name="pref_transaction_hide_reconciled_amounts_title">Hide Reconciled Amounts</string>
+    <string name="pref_transaction_sort_by_type_summary">Arrange daily transactions by transaction type (deposit, transfer, withdrawal)</string>
+    <string name="pref_transaction_sort_by_type_title">Sort Transactions by Type</string>
     <string name="warning">Warning</string>
     <string name="no_transfer_splits">You have chosen to switch to Transfer but there are Split Categories on the transaction. Do you want to proceed and remove the Split Categories?</string>
     <string name="qif_export">Qif Export</string>

--- a/app/src/main/res/xml/look_and_feel_settings.xml
+++ b/app/src/main/res/xml/look_and_feel_settings.xml
@@ -58,6 +58,13 @@
         android:summary="@string/pref_transaction_hide_reconciled_amounts_summary"
         android:title="@string/pref_transaction_hide_reconciled_amounts_title"/>
 
+    <CheckBoxPreference
+        android:defaultValue="true"
+        android:icon="@null"
+        android:key="@string/pref_transaction_sort_by_type"
+        android:summary="@string/pref_transaction_sort_by_type_summary"
+        android:title="@string/pref_transaction_sort_by_type_title"/>
+
     <ListPreference
         android:defaultValue="-1"
         android:entries="@array/application_font_entries"


### PR DESCRIPTION
Duplicate of the #880 for the dev branch.

Current sorting is [Date DESC, TransactionType, ID DESC]. If "Shows the balance for each transaction" is enabled, it can create create situation when some transaction have negative balance.
I have added option to have sorting by [Date DESC, ID DESC] that will sort transaction as they were added.