### PR TITLE
Fix #881. Apply transaction-related preferences without the app restart.

### DIFF
--- a/app/src/main/java/com/money/manager/ex/account/AccountTransactionListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/account/AccountTransactionListFragment.java
@@ -140,12 +140,7 @@ public class AccountTransactionListFragment
         this.mFilter = new TransactionFilter();
 
         // Select the default period.
-        DefinedDateRangeName rangeName = new AppSettings(getActivity()).getLookAndFeelSettings()
-            .getShowTransactions();
-        DefinedDateRanges ranges = new DefinedDateRanges(getActivity());
-        DefinedDateRange range = ranges.get(rangeName);
-
-        mFilter.dateRange = MyDateTimeUtils.getDateRangeForPeriod(getActivity(), range.nameResourceId);
+        updateFilterDateRange();
 
         // Default value.
         mFilter.transactionStatus = new StatusFilter();
@@ -836,8 +831,7 @@ public class AccountTransactionListFragment
         mAllDataListFragment.getArguments().putAll(searchQuery);
 
         if (header != null) mAllDataListFragment.setListHeader(header);
-        mAllDataListFragment.setShownBalance(PreferenceManager.getDefaultSharedPreferences(getActivity())
-            .getBoolean(getString(PreferenceConstants.PREF_TRANSACTION_SHOWN_BALANCE), false));
+        updateAllDataListFragmentShowBalance();
         mAllDataListFragment.setAutoStarLoader(false);
         mAllDataListFragment.setSearResultFragmentLoaderCallbacks(this);
 
@@ -875,5 +869,28 @@ public class AccountTransactionListFragment
 
     private void refreshSettings() {
         mSortTransactionsByType = new AppSettings(getActivity()).getLookAndFeelSettings().getSortTransactionsByType();
+
+        updateFilterDateRange();
+        updateAllDataListFragmentShowBalance();
+
+        getActivity().invalidateOptionsMenu();
+    }
+
+    private void updateFilterDateRange() {
+        DefinedDateRangeName rangeName = new AppSettings(getActivity()).getLookAndFeelSettings()
+            .getShowTransactions();
+        DefinedDateRanges ranges = new DefinedDateRanges(getActivity());
+        DefinedDateRange range = ranges.get(rangeName);
+
+        mFilter.dateRange = MyDateTimeUtils.getDateRangeForPeriod(getActivity(), range.nameResourceId);
+    }
+
+    private void updateAllDataListFragmentShowBalance() {
+        if (mAllDataListFragment == null) {
+            return;
+        }
+
+        mAllDataListFragment.setShownBalance(PreferenceManager.getDefaultSharedPreferences(getActivity())
+                .getBoolean(getString(PreferenceConstants.PREF_TRANSACTION_SHOWN_BALANCE), false));
     }
 }

--- a/app/src/main/java/com/money/manager/ex/common/AllDataListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/common/AllDataListFragment.java
@@ -589,6 +589,13 @@ public class AllDataListFragment
      */
     public void setShownBalance(boolean mShownBalance) {
         this.mShowBalance = mShownBalance;
+
+        AllDataAdapter adapter = getAllDataAdapter();
+        if (adapter == null) {
+            return;
+        }
+
+        adapter.setShowBalanceAmount(mShownBalance);
     }
 
     public void showTotalsFooter() {

--- a/app/src/main/java/com/money/manager/ex/home/HomeFragment.java
+++ b/app/src/main/java/com/money/manager/ex/home/HomeFragment.java
@@ -138,8 +138,7 @@ public class HomeFragment
 
         mCurrencyService = new CurrencyService(getActivity().getApplicationContext());
 
-        AppSettings settings = new AppSettings(getActivity());
-        mHideReconciled = settings.getLookAndFeelSettings().getHideReconciledAmounts();
+        refreshSettings();
 
         // The fragment is using a custom option in the actionbar menu.
         setHasOptionsMenu(true);
@@ -388,6 +387,8 @@ public class HomeFragment
     @Override
     public void onResume() {
         super.onResume();
+
+        refreshSettings();
 
         // Toolbar
         Activity parent = getActivity();
@@ -962,5 +963,14 @@ public class HomeFragment
     private ExpandableListView getExpandableListView(View view) {
         mExpandableListView = (ExpandableListView) view.findViewById(R.id.listViewAccountBills);
         return mExpandableListView;
+    }
+
+    private void refreshSettings() {
+        AppSettings settings = new AppSettings(getActivity());
+        mHideReconciled = settings.getLookAndFeelSettings().getHideReconciledAmounts();
+
+        if (txtFooterSummaryReconciled != null) {
+            txtFooterSummaryReconciled.setVisibility(mHideReconciled ? View.GONE : View.VISIBLE);
+        }
     }
 }


### PR DESCRIPTION
Fixed "Show Transaction", "Show the balance for each transaction", "Hide Reconciled Amounts" preferences.