### PR TITLE
RecurringTransactionService set month to the next month before finding last date (rules 15,16)

### DIFF
--- a/app/src/main/java/com/money/manager/ex/servicelayer/RecurringTransactionService.java
+++ b/app/src/main/java/com/money/manager/ex/servicelayer/RecurringTransactionService.java
@@ -125,11 +125,15 @@ public class RecurringTransactionService
                 result = result.plusMonths(numberOfPeriods);
                 break;
             case MONTHLY_LAST_DAY: //month (last day)
-                result = result.dayOfMonth().withMaximumValue();
+                //one liner
+                //  result = result.dayOfMonth().withMinimumValue().plusMonths(1).dayOfMonth().withMaximumValue();
+                result = result.dayOfMonth().withMinimumValue();
+                result = result.plusMonths(1).dayOfMonth().withMaximumValue();
                 break;
             case MONTHLY_LAST_BUSINESS_DAY: //month (last business day)
-                // get the last day of the month,
-                result = result.dayOfMonth().withMaximumValue();
+                // get the last day of the next month,
+                result = result.dayOfMonth().withMinimumValue();
+                result = result.plusMonths(1).dayOfMonth().withMaximumValue();
                 // then iterate backwards until we are not on weekend day.
                 while(result.getDayOfWeek() == DateTimeConstants.SATURDAY ||
                         result.getDayOfWeek() == DateTimeConstants.SUNDAY) {


### PR DESCRIPTION
When using MMEX Android, if the recurrence type was set to MONTHLY_LAST_DAY or MONTHLY_LAST_BUSINESS_DAY (15, 16 respectively), the month would not advance.