### PR TITLE
Enhanced budgeting

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -224,6 +224,9 @@
             android:name=".settings.InvestmentSettingsActivity"
             android:label="@string/investment" />
         <activity
+            android:name=".settings.BudgetSettingsActivity"
+            android:label="@string/budget" />
+        <activity
             android:name=".settings.SecuritySettingsActivity"
             android:label="@string/preferences_security" />
         <activity

--- a/app/src/main/java/com/money/manager/ex/budget/BudgetAdapter.java
+++ b/app/src/main/java/com/money/manager/ex/budget/BudgetAdapter.java
@@ -22,7 +22,6 @@ import android.database.sqlite.SQLiteQueryBuilder;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.widget.SimpleCursorAdapter;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -38,6 +37,7 @@ import com.money.manager.ex.log.ExceptionHandler;
 import com.money.manager.ex.currency.CurrencyService;
 import com.money.manager.ex.database.SQLDataSet;
 import com.money.manager.ex.database.ViewMobileData;
+import com.money.manager.ex.settings.AppSettings;
 import com.squareup.sqlbrite.BriteDatabase;
 
 import javax.inject.Inject;
@@ -70,8 +70,10 @@ public class BudgetAdapter
     public BudgetAdapter(Context context, Cursor cursor, String[] from, int[] to, int flags) {
         super(context, R.layout.item_budget, cursor, from, to, flags);
 
+        // switch to simple layout if the showSimpleView is set
+        AppSettings settings = new AppSettings(getContext());
+        mLayout = (settings.getBudgetSettings().getShowSimpleView()) ? R.layout.item_budget_simple : R.layout.item_budget;
         mContext = context;
-        mLayout = R.layout.item_budget;
 
         MoneyManagerApplication.getApp().iocComponent.inject(this);
     }
@@ -136,17 +138,19 @@ public class BudgetAdapter
 
             // colour the amount depending on whether it is above/below the budgeted amount to 2 decimal places
             UIHelper uiHelper = new UIHelper(context);
-            if ((int) actual * 100 < (int) amount * 100) {
-                actualTextView.setTextColor(ContextCompat.getColor(context, uiHelper.resolveAttribute(R.attr.holo_red_color_theme)));
+            if ((int) (actual * 100) < (int) (amount * 100)) {
+                actualTextView.setTextColor(
+                        ContextCompat.getColor(context, uiHelper.resolveAttribute(R.attr.holo_red_color_theme))
+                );
             } else {
-                actualTextView.setTextColor(ContextCompat.getColor(context, uiHelper.resolveAttribute(R.attr.holo_green_color_theme)));
+                actualTextView.setTextColor(
+                        ContextCompat.getColor(context, uiHelper.resolveAttribute(R.attr.holo_green_color_theme))
+                );
             }
         }
 
         // Amount Available
-        // @todo: calculating income is weird... when the number have different signs (+ and -)
-        // @todo:  - the planned income amount is negative, but the actual amount is positive..
-        //           error in the query?
+
         TextView amountAvailableTextView = (TextView) view.findViewById(R.id.amountAvailableTextView);
         if (amountAvailableTextView != null) {
             double amountAvailable = -(amount - actual);
@@ -155,13 +159,15 @@ public class BudgetAdapter
 
             // colour the amount depending on whether it is above/below the budgeted amount to 2 decimal places
             UIHelper uiHelper = new UIHelper(context);
-
             int amountAvailableInt = (int) (amountAvailable * 100);
-            Log.w("amounts", "" + amountAvailableInt);
             if (amountAvailableInt < 0) {
-                amountAvailableTextView.setTextColor(ContextCompat.getColor(context, uiHelper.resolveAttribute(R.attr.holo_red_color_theme)));
+                amountAvailableTextView.setTextColor(
+                        ContextCompat.getColor(context, uiHelper.resolveAttribute(R.attr.holo_red_color_theme))
+                );
             } else if (amountAvailableInt > 0) {
-                amountAvailableTextView.setTextColor(ContextCompat.getColor(context, uiHelper.resolveAttribute(R.attr.holo_green_color_theme)));
+                amountAvailableTextView.setTextColor(
+                        ContextCompat.getColor(context, uiHelper.resolveAttribute(R.attr.holo_green_color_theme))
+                );
             }
         }
     }

--- a/app/src/main/java/com/money/manager/ex/budget/BudgetAdapter.java
+++ b/app/src/main/java/com/money/manager/ex/budget/BudgetAdapter.java
@@ -140,11 +140,11 @@ public class BudgetAdapter
             UIHelper uiHelper = new UIHelper(context);
             if ((int) (actual * 100) < (int) (amount * 100)) {
                 actualTextView.setTextColor(
-                        ContextCompat.getColor(context, uiHelper.resolveAttribute(R.attr.holo_red_color_theme))
+                    ContextCompat.getColor(context, uiHelper.resolveAttribute(R.attr.holo_red_color_theme))
                 );
             } else {
                 actualTextView.setTextColor(
-                        ContextCompat.getColor(context, uiHelper.resolveAttribute(R.attr.holo_green_color_theme))
+                    ContextCompat.getColor(context, uiHelper.resolveAttribute(R.attr.holo_green_color_theme))
                 );
             }
         }
@@ -162,11 +162,11 @@ public class BudgetAdapter
             int amountAvailableInt = (int) (amountAvailable * 100);
             if (amountAvailableInt < 0) {
                 amountAvailableTextView.setTextColor(
-                        ContextCompat.getColor(context, uiHelper.resolveAttribute(R.attr.holo_red_color_theme))
+                    ContextCompat.getColor(context, uiHelper.resolveAttribute(R.attr.holo_red_color_theme))
                 );
             } else if (amountAvailableInt > 0) {
                 amountAvailableTextView.setTextColor(
-                        ContextCompat.getColor(context, uiHelper.resolveAttribute(R.attr.holo_green_color_theme))
+                    ContextCompat.getColor(context, uiHelper.resolveAttribute(R.attr.holo_green_color_theme))
                 );
             }
         }
@@ -175,7 +175,7 @@ public class BudgetAdapter
     private double getActualAmount(boolean hasSubcategory, Cursor cursor) {
         double actual;
         if (!hasSubcategory) {
-            // @todo: get sum of subcategory
+            // @todo: get sum of subcategories?
             int categoryId = cursor.getInt(cursor.getColumnIndex(BudgetQuery.CATEGID));
             actual = getAmountForCategory(categoryId);
         } else {

--- a/app/src/main/java/com/money/manager/ex/budget/BudgetAdapter.java
+++ b/app/src/main/java/com/money/manager/ex/budget/BudgetAdapter.java
@@ -115,9 +115,8 @@ public class BudgetAdapter
         BudgetPeriodEnum periodEnum = getBudgetPeriodFor(categoryId, subCategoryId);
 
         TextView frequencyTextView = (TextView) view.findViewById(R.id.frequencyTextView);
-        String frequencyText = BudgetPeriods.getPeriodTranslationForEnum(mContext, periodEnum);
         if (frequencyTextView != null) {
-            frequencyTextView.setText(frequencyText);
+            frequencyTextView.setText(BudgetPeriods.getPeriodTranslationForEnum(mContext, periodEnum));
         }
 
         CurrencyService currencyService = new CurrencyService(mContext);

--- a/app/src/main/java/com/money/manager/ex/budget/BudgetAdapter.java
+++ b/app/src/main/java/com/money/manager/ex/budget/BudgetAdapter.java
@@ -125,10 +125,10 @@ public class BudgetAdapter
         }
 
         // Estimated
-        BudgetPeriodEnum budgetPeriodIndex = BudgetPeriods.getEnum(frequencyText);
+        BudgetPeriodEnum periodEnum = BudgetPeriods.getEnum(frequencyText);
         double estimated = ((isMonthlyBudget(mBudgetName))
-                ? BudgetPeriods.getMonthlyEstimate(budgetPeriodIndex, amount)
-                : BudgetPeriods.getYearlyEstimate(budgetPeriodIndex, amount)
+                ? BudgetPeriods.getMonthlyEstimate(periodEnum, amount)
+                : BudgetPeriods.getYearlyEstimate(periodEnum, amount)
         );
 
         // Actual

--- a/app/src/main/java/com/money/manager/ex/budget/BudgetAdapter.java
+++ b/app/src/main/java/com/money/manager/ex/budget/BudgetAdapter.java
@@ -19,6 +19,7 @@ package com.money.manager.ex.budget;
 import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteQueryBuilder;
+import android.support.v4.content.ContextCompat;
 import android.support.v4.widget.SimpleCursorAdapter;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
@@ -30,6 +31,7 @@ import android.widget.TextView;
 import com.money.manager.ex.Constants;
 import com.money.manager.ex.MoneyManagerApplication;
 import com.money.manager.ex.R;
+import com.money.manager.ex.core.UIHelper;
 import com.money.manager.ex.datalayer.Select;
 import com.money.manager.ex.log.ExceptionHandler;
 import com.money.manager.ex.currency.CurrencyService;
@@ -117,15 +119,14 @@ public class BudgetAdapter
         // Amount
 
         TextView amountTextView = (TextView) view.findViewById(R.id.amountTextView);
+        double amount = cursor.getDouble(cursor.getColumnIndex(BudgetQuery.AMOUNT));
         if (amountTextView != null) {
-            double amount = cursor.getDouble(cursor.getColumnIndex(BudgetQuery.AMOUNT));
             String text = currencyService.getBaseCurrencyFormatted(MoneyFactory.fromDouble(amount));
             amountTextView.setText(text);
         }
 
         // Estimated
         // Actual
-        // todo: colour the amount depending on whether it is above/below the budgeted amount.
         TextView actualTextView = (TextView) view.findViewById(R.id.actualTextView);
         if (actualTextView != null) {
             double actual;
@@ -139,6 +140,14 @@ public class BudgetAdapter
 
             String actualString = currencyService.getBaseCurrencyFormatted(MoneyFactory.fromDouble(actual));
             actualTextView.setText(actualString);
+
+            // colour the amount depending on whether it is above/below the budgeted amount to 2 decimal places
+            UIHelper uiHelper = new UIHelper(context);
+            if ((int) actual * 100 < (int) amount * 100) {
+                actualTextView.setTextColor(ContextCompat.getColor(context, uiHelper.resolveAttribute(R.attr.holo_red_color_theme)));
+            } else {
+                actualTextView.setTextColor(ContextCompat.getColor(context, uiHelper.resolveAttribute(R.attr.holo_green_color_theme)));
+            }
         }
     }
 

--- a/app/src/main/java/com/money/manager/ex/budget/BudgetAdapter.java
+++ b/app/src/main/java/com/money/manager/ex/budget/BudgetAdapter.java
@@ -112,7 +112,7 @@ public class BudgetAdapter
 
         // Frequency
 
-        BudgetPeriodEnum periodEnum = getBudgetFrequencyFor(categoryId, subCategoryId);
+        BudgetPeriodEnum periodEnum = getBudgetPeriodFor(categoryId, subCategoryId);
 
         TextView frequencyTextView = (TextView) view.findViewById(R.id.frequencyTextView);
         String frequencyText = BudgetPeriods.getPeriodTranslationForEnum(mContext, periodEnum);
@@ -228,12 +228,12 @@ public class BudgetAdapter
     }
 
     /**
-     * Returns the frequency of the budgeted amount or NONE if there isn't any.
+     * Returns the period of the budgeted amount or NONE if there isn't any.
      * @param categoryId
      * @param subCategoryId
      * @return
      */
-    private BudgetPeriodEnum getBudgetFrequencyFor(int categoryId, int subCategoryId) {
+    private BudgetPeriodEnum getBudgetPeriodFor(int categoryId, int subCategoryId) {
         String key = BudgetEntryRepository.getKeyForCategories(categoryId, subCategoryId);
         return mBudgetEntries.containsKey(key)
                 ? BudgetPeriods.getEnum(mBudgetEntries.get(key).getContentValues().getAsString(BudgetQuery.PERIOD))

--- a/app/src/main/java/com/money/manager/ex/budget/BudgetDetailFragment.java
+++ b/app/src/main/java/com/money/manager/ex/budget/BudgetDetailFragment.java
@@ -47,6 +47,7 @@ public class BudgetDetailFragment
     private final int LOADER_BUDGET = 1;
     private long mBudgetYearId = Constants.NOT_SET;
     private String mBudgetName;
+    private View mHeader;
 
     /**
      * Use this factory method to create a new instance of
@@ -93,13 +94,23 @@ public class BudgetDetailFragment
         ListView list = (ListView) view.findViewById(android.R.id.list);
 
         // Add the column header.
-        View header = View.inflate(getActivity(), R.layout.item_budget_header, null);
-        list.addHeaderView(header);
+        mHeader = View.inflate(getActivity(), R.layout.item_budget_header, null);
+        list.addHeaderView(mHeader);
         // Header has to be added before the adapter is set on the list.
 
         setUpAdapter();
 
         return view;
+    }
+
+    // Got random IndexOutOfBoundsException during loading the new fragment
+    // reference: http://stackoverflow.com/a/28463811
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        if (getListView().getHeaderViewsCount() > 0) {
+            getListView().removeHeaderView(mHeader);
+        }
     }
 
     @Override

--- a/app/src/main/java/com/money/manager/ex/budget/BudgetDetailFragment.java
+++ b/app/src/main/java/com/money/manager/ex/budget/BudgetDetailFragment.java
@@ -33,6 +33,7 @@ import com.money.manager.ex.common.MmxCursorLoader;
 import com.money.manager.ex.datalayer.BudgetRepository;
 import com.money.manager.ex.datalayer.Select;
 import com.money.manager.ex.domainmodel.Budget;
+import com.money.manager.ex.settings.AppSettings;
 
 /**
  * Use the {@link BudgetDetailFragment#newInstance} factory method to
@@ -94,7 +95,11 @@ public class BudgetDetailFragment
         ListView list = (ListView) view.findViewById(android.R.id.list);
 
         // Add the column header.
-        mHeader = View.inflate(getActivity(), R.layout.item_budget_header, null);
+        // switch to simple layout if the showSimpleView is set
+        AppSettings settings = new AppSettings(getContext());
+        int layout = (settings.getBudgetSettings().getShowSimpleView()) ? R.layout.item_budget_simple_header : R.layout.item_budget_header;
+
+        mHeader = View.inflate(getActivity(), layout, null);
         list.addHeaderView(mHeader);
         // Header has to be added before the adapter is set on the list.
 

--- a/app/src/main/java/com/money/manager/ex/budget/BudgetDetailFragment.java
+++ b/app/src/main/java/com/money/manager/ex/budget/BudgetDetailFragment.java
@@ -18,7 +18,6 @@ package com.money.manager.ex.budget;
 
 import android.database.Cursor;
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
 import android.support.v4.app.LoaderManager;
 import android.support.v4.content.Loader;
 import android.view.LayoutInflater;
@@ -30,9 +29,8 @@ import com.money.manager.ex.Constants;
 import com.money.manager.ex.R;
 import com.money.manager.ex.common.BaseListFragment;
 import com.money.manager.ex.common.MmxCursorLoader;
-import com.money.manager.ex.datalayer.BudgetRepository;
+import com.money.manager.ex.database.QueryCategorySubCategory;
 import com.money.manager.ex.datalayer.Select;
-import com.money.manager.ex.domainmodel.Budget;
 import com.money.manager.ex.settings.AppSettings;
 
 /**
@@ -141,6 +139,7 @@ public class BudgetDetailFragment
                 0);
 
         adapter.setBudgetName(mBudgetName);
+        adapter.setBudgetYearId(mBudgetYearId);
 
         setListAdapter(adapter);
     }
@@ -153,12 +152,11 @@ public class BudgetDetailFragment
 
                 switch (id) {
                     case LOADER_BUDGET:
-                        BudgetQuery budget = new BudgetQuery(getActivity());
-                        Select query = new Select(budget.getAllColumns())
-                            .where(BudgetQuery.BUDGETYEARID + "=?", mBudgetYearId)
-                            .orderBy(BudgetQuery.CATEGNAME + ", " + BudgetQuery.SUBCATEGNAME);
+                        QueryCategorySubCategory categories = new QueryCategorySubCategory(getActivity());
+                        Select query = new Select(categories.getAllColumns())
+                            .orderBy(QueryCategorySubCategory.CATEGSUBNAME);
 
-                        result = new MmxCursorLoader(getActivity(), budget.getUri(), query);
+                        result = new MmxCursorLoader(getActivity(), categories.getUri(), query);
                         break;
                 }
                 return result;

--- a/app/src/main/java/com/money/manager/ex/budget/BudgetPeriodEnum.java
+++ b/app/src/main/java/com/money/manager/ex/budget/BudgetPeriodEnum.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2012-2016 The Android Money Manager Ex Project Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.money.manager.ex.budget;
+
+/**
+ * Budget period
+ */
+
+public enum BudgetPeriodEnum {
+    NONE,
+    WEEKLY,
+    BI_WEEKLY,
+    MONTHLY,
+    BI_MONTHLY,
+    QUARTERLY,
+    HALF_YEARLY,
+    YEARLY,
+    DAILY
+}

--- a/app/src/main/java/com/money/manager/ex/budget/BudgetPeriods.java
+++ b/app/src/main/java/com/money/manager/ex/budget/BudgetPeriods.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2012-2016 The Android Money Manager Ex Project Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.money.manager.ex.budget;
+
+import android.content.Context;
+
+import com.money.manager.ex.R;
+
+import java.util.HashMap;
+
+/**
+ * Budget period helper
+ */
+public class BudgetPeriods {
+
+    private static HashMap<String, BudgetPeriodEnum> periodEnumLookup = null;
+    private static HashMap<BudgetPeriodEnum, String> periodTranslationLookup = null;
+
+    /**
+     * Returns proper enum for period name in the database
+     * @param periodString
+     * @return
+     */
+    public static BudgetPeriodEnum getEnum(String periodString) {
+        if (periodEnumLookup == null) {
+            periodEnumLookup = new HashMap<>();
+        }
+
+        if (periodEnumLookup.size() == 0) {
+            periodEnumLookup.put("None"       , BudgetPeriodEnum.NONE);
+            periodEnumLookup.put("Weekly"     , BudgetPeriodEnum.WEEKLY);
+            periodEnumLookup.put("Bi-Weekly"  , BudgetPeriodEnum.BI_WEEKLY);
+            periodEnumLookup.put("Monthly"    , BudgetPeriodEnum.MONTHLY);
+            periodEnumLookup.put("Bi-Monthly" , BudgetPeriodEnum.BI_MONTHLY);
+            periodEnumLookup.put("Quarterly"  , BudgetPeriodEnum.QUARTERLY);
+            periodEnumLookup.put("Half-Yearly", BudgetPeriodEnum.HALF_YEARLY);
+            periodEnumLookup.put("Yearly"     , BudgetPeriodEnum.YEARLY);
+            periodEnumLookup.put("Daily"      , BudgetPeriodEnum.DAILY);
+        }
+
+        return periodEnumLookup.containsKey(periodString) ? periodEnumLookup.get(periodString) : BudgetPeriodEnum.NONE;
+    }
+
+    /**
+     * Trampoline for translation by enum
+     * @param context
+     * @param periodString
+     * @return
+     */
+    public static String getPeriodTranslationForEnum(Context context, String periodString) {
+        return getPeriodTranslationForEnum(context, getEnum(periodString));
+    }
+
+    /**
+     * Helper function to translate the string literals of period in the database.
+     * @param context
+     * @param periodEnum string value from the database
+     * @return translated string
+     */
+    public static String getPeriodTranslationForEnum(Context context, BudgetPeriodEnum periodEnum) {
+        if (periodTranslationLookup == null) {
+            periodTranslationLookup = new HashMap<>();
+        }
+
+        if (periodTranslationLookup.size() == 0) {
+            periodTranslationLookup.put(BudgetPeriodEnum.NONE, context.getString(R.string.none));
+            periodTranslationLookup.put(BudgetPeriodEnum.WEEKLY, context.getString(R.string.weekly));
+            periodTranslationLookup.put(BudgetPeriodEnum.BI_WEEKLY, context.getString(R.string.bi_weekly));
+            periodTranslationLookup.put(BudgetPeriodEnum.MONTHLY, context.getString(R.string.monthly));
+            periodTranslationLookup.put(BudgetPeriodEnum.BI_MONTHLY, context.getString(R.string.bi_monthly));
+            periodTranslationLookup.put(BudgetPeriodEnum.QUARTERLY, context.getString(R.string.quaterly));
+            periodTranslationLookup.put(BudgetPeriodEnum.HALF_YEARLY, context.getString(R.string.half_year));
+            periodTranslationLookup.put(BudgetPeriodEnum.YEARLY, context.getString(R.string.yearly));
+            periodTranslationLookup.put(BudgetPeriodEnum.DAILY, context.getString(R.string.daily));
+        }
+
+        return periodTranslationLookup.containsKey(periodEnum)
+                ? periodTranslationLookup.get(periodEnum)
+                : context.getString(R.string.none);
+    }
+
+    public static double getMonthlyEstimate(BudgetPeriodEnum periodEnum, double amount) {
+        double estimated = 0;
+        int ndays = 365;
+        if (periodEnum == BudgetPeriodEnum.MONTHLY) {
+            estimated = amount;
+        }
+        else if (periodEnum == BudgetPeriodEnum.YEARLY) {
+            estimated = amount / 12;
+        }
+        else if (periodEnum == BudgetPeriodEnum.WEEKLY) {
+            estimated = ((amount / 7) * ndays) / 12;
+        }
+        else if (periodEnum == BudgetPeriodEnum.BI_WEEKLY) {
+            estimated = ((amount / 14) * ndays) / 12;
+        }
+        else if (periodEnum == BudgetPeriodEnum.BI_MONTHLY) {
+            estimated = amount / 2;
+        }
+        else if (periodEnum == BudgetPeriodEnum.QUARTERLY) {
+            estimated = amount / 3;
+        }
+        else if (periodEnum == BudgetPeriodEnum.HALF_YEARLY) {
+            estimated = (amount / 6);
+        }
+        else if (periodEnum == BudgetPeriodEnum.DAILY) {
+            estimated = (amount * ndays) / 12;
+        }
+
+        return estimated;
+    }
+
+    public static double getYearlyEstimate(BudgetPeriodEnum periodEnum, double amount) {
+        double estimated = 0;
+        if (periodEnum == BudgetPeriodEnum.MONTHLY) {
+            estimated = amount * 12;
+        }
+        else if (periodEnum == BudgetPeriodEnum.YEARLY) {
+            estimated = amount;
+        }
+        else if (periodEnum == BudgetPeriodEnum.WEEKLY) {
+            estimated = amount * 52;
+        }
+        else if (periodEnum == BudgetPeriodEnum.BI_WEEKLY) {
+            estimated = amount * 26;
+        }
+        else if (periodEnum == BudgetPeriodEnum.BI_MONTHLY) {
+            estimated = amount * 6;
+        }
+        else if (periodEnum == BudgetPeriodEnum.QUARTERLY) {
+            estimated = amount * 4;
+        }
+        else if (periodEnum == BudgetPeriodEnum.HALF_YEARLY) {
+            estimated = amount * 2;
+        }
+        else if (periodEnum== BudgetPeriodEnum.DAILY) {
+            estimated = amount * 365;
+        }
+
+        return estimated;
+    }
+}

--- a/app/src/main/java/com/money/manager/ex/budget/BudgetPeriods.java
+++ b/app/src/main/java/com/money/manager/ex/budget/BudgetPeriods.java
@@ -148,7 +148,7 @@ public class BudgetPeriods {
         else if (periodEnum == BudgetPeriodEnum.HALF_YEARLY) {
             estimated = amount * 2;
         }
-        else if (periodEnum== BudgetPeriodEnum.DAILY) {
+        else if (periodEnum == BudgetPeriodEnum.DAILY) {
             estimated = amount * 365;
         }
 

--- a/app/src/main/java/com/money/manager/ex/budget/BudgetsActivity.java
+++ b/app/src/main/java/com/money/manager/ex/budget/BudgetsActivity.java
@@ -171,8 +171,10 @@ public class BudgetsActivity
             // todo: enable going back only if showing the list.
 //            boolean showingList = tagFragment.equals(BudgetListFragment.class.getName());
 //            setDisplayHomeAsUpEnabled(showingList);
+
+            transaction.addToBackStack(null);
         }
-        transaction.addToBackStack(null);
+
         // Commit the transaction
         transaction.commit();
     }

--- a/app/src/main/java/com/money/manager/ex/datalayer/BudgetEntryRepository.java
+++ b/app/src/main/java/com/money/manager/ex/datalayer/BudgetEntryRepository.java
@@ -18,20 +18,25 @@
 package com.money.manager.ex.datalayer;
 
 import android.content.Context;
+import android.database.Cursor;
 
+import com.money.manager.ex.Constants;
 import com.money.manager.ex.database.DatasetType;
+import com.money.manager.ex.database.WhereStatementGenerator;
 import com.money.manager.ex.domainmodel.BudgetEntry;
+
+import java.util.HashMap;
 
 /**
  * Budget Entry repository.
- * Table: budgettable_v1
  */
 public class BudgetEntryRepository
         extends RepositoryBase<BudgetEntry> {
 
-    public BudgetEntryRepository(Context context) {
-        super(context, "budgettable_v1", DatasetType.TABLE, "budgettable");
+    public static final String TABLE_NAME = "budgettable_v1";
 
+    public BudgetEntryRepository(Context context) {
+        super(context, TABLE_NAME, DatasetType.TABLE, "budgettable");
     }
 
     @Override
@@ -42,6 +47,59 @@ public class BudgetEntryRepository
                 BudgetEntry.CATEGID,
                 BudgetEntry.SUBCATEGID,
                 BudgetEntry.PERIOD};
+    }
+
+    public BudgetEntry load(int id) {
+        if (id == Constants.NOT_SET) return null;
+
+        WhereStatementGenerator where = new WhereStatementGenerator();
+        where.addStatement(BudgetEntry.BUDGETENTRYID, "=", id);
+
+        BudgetEntry result = super.first(BudgetEntry.class,
+                null,
+                where.getWhere(),
+                null,
+                null);
+        return result;
+    }
+
+    /**
+     * Returns a string value which is used as a key in the budget entry thread cache
+     * @param categoryId
+     * @param subCategoryId
+     * @return
+     */
+    public static String getKeyForCategories(int categoryId, int subCategoryId) {
+        return Integer.toString(categoryId) + "_" + Integer.toString(subCategoryId);
+    }
+
+    public HashMap<String, BudgetEntry> loadForYear(long budgetYearId) {
+        if (budgetYearId == Constants.NOT_SET) return null;
+
+        WhereStatementGenerator where = new WhereStatementGenerator();
+        where.addStatement(BudgetEntry.BUDGETYEARID, "=", budgetYearId);
+
+        Cursor cursor = getContext().getContentResolver().query(getUri(),
+                null,
+                where.getWhere(),
+                null,
+                null);
+        if (cursor == null) return null;
+
+        HashMap<String, BudgetEntry> budgetEntryHashMap = new HashMap<>();
+
+        while (cursor.moveToNext()) {
+            BudgetEntry budgetEntry = new BudgetEntry();
+            budgetEntry.loadFromCursor(cursor);
+
+            int categoryId = cursor.getInt(cursor.getColumnIndex(BudgetEntry.CATEGID));
+            int subcategoryId = cursor.getInt(cursor.getColumnIndex(BudgetEntry.SUBCATEGID));
+
+            budgetEntryHashMap.put(getKeyForCategories(categoryId, subcategoryId), budgetEntry);
+        }
+        cursor.close();
+
+        return budgetEntryHashMap;
     }
 
 }

--- a/app/src/main/java/com/money/manager/ex/settings/AppSettings.java
+++ b/app/src/main/java/com/money/manager/ex/settings/AppSettings.java
@@ -49,6 +49,7 @@ public class AppSettings
     private LookAndFeelSettings mLookAndFeel;
     private BehaviourSettings mBehaviour;
     private InvestmentSettings mInvestment;
+    private BudgetSettings mBudget;
     private DatabaseSettings mDatabase;
 
     @Override
@@ -88,6 +89,13 @@ public class AppSettings
             mInvestment = new InvestmentSettings(getContext());
         }
         return mInvestment;
+    }
+
+    public BudgetSettings getBudgetSettings() {
+        if (mBudget == null) {
+            mBudget = new BudgetSettings(getContext());
+        }
+        return mBudget;
     }
 
     // Individual preferences.

--- a/app/src/main/java/com/money/manager/ex/settings/BudgetSettings.java
+++ b/app/src/main/java/com/money/manager/ex/settings/BudgetSettings.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2012-2016 The Android Money Manager Ex Project Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.money.manager.ex.settings;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.text.TextUtils;
+
+import com.money.manager.ex.R;
+import com.money.manager.ex.core.DefinedDateRange;
+import com.money.manager.ex.core.DefinedDateRangeName;
+import com.money.manager.ex.core.DefinedDateRanges;
+import com.money.manager.ex.core.InfoKeys;
+import com.money.manager.ex.servicelayer.InfoService;
+
+import timber.log.Timber;
+
+/**
+ * Budget preferences
+ */
+public class BudgetSettings
+    extends SettingsBase {
+
+    public BudgetSettings(Context context) {
+        super(context);
+    }
+
+    @Override
+    protected SharedPreferences getPreferences() {
+        return PreferenceManager.getDefaultSharedPreferences(getContext());
+    }
+
+    public Boolean getShowSimpleView() {
+        return get(R.string.pref_budget_show_simple_view, false);
+    }
+
+    public void setShowSimpleView(boolean value) {
+        set(R.string.pref_budget_show_simple_view, value);
+    }
+
+}

--- a/app/src/main/java/com/money/manager/ex/settings/BudgetSettingsActivity.java
+++ b/app/src/main/java/com/money/manager/ex/settings/BudgetSettingsActivity.java
@@ -18,7 +18,6 @@
 package com.money.manager.ex.settings;
 
 import android.os.Bundle;
-import android.util.Log;
 
 public class BudgetSettingsActivity
     extends BaseSettingsFragmentActivity {
@@ -26,7 +25,6 @@ public class BudgetSettingsActivity
     @Override
     protected void onCreate(Bundle savedInstance) {
         super.onCreate(savedInstance);
-        Log.w("budget", "BudgetSettingsActivity onCreate is called.");
         setSettingFragment(new BudgetSettingsFragment());
     }
 }

--- a/app/src/main/java/com/money/manager/ex/settings/BudgetSettingsActivity.java
+++ b/app/src/main/java/com/money/manager/ex/settings/BudgetSettingsActivity.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2012-2016 The Android Money Manager Ex Project Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.money.manager.ex.settings;
+
+import android.os.Bundle;
+import android.util.Log;
+
+public class BudgetSettingsActivity
+    extends BaseSettingsFragmentActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstance) {
+        super.onCreate(savedInstance);
+        Log.w("budget", "BudgetSettingsActivity onCreate is called.");
+        setSettingFragment(new BudgetSettingsFragment());
+    }
+}

--- a/app/src/main/java/com/money/manager/ex/settings/BudgetSettingsFragment.java
+++ b/app/src/main/java/com/money/manager/ex/settings/BudgetSettingsFragment.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2012-2016 The Android Money Manager Ex Project Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.money.manager.ex.settings;
+
+import android.os.Bundle;
+import android.support.v7.preference.PreferenceFragmentCompat;
+
+import com.money.manager.ex.R;
+
+/**
+ * Budget preferences.
+ */
+public class BudgetSettingsFragment
+    extends PreferenceFragmentCompat {
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+//        PreferenceManager.getDefaultSharedPreferences(getActivity());
+    }
+
+    @Override
+    public void onCreatePreferences(Bundle bundle, String s) {
+        // use either setPreferenceScreen(PreferenceScreen) or addPreferencesFromResource(int).
+
+        addPreferencesFromResource(R.xml.preferences_budget);
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+
+//        EventBus.getDefault().register(this);
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+
+//        EventBus.getDefault().unregister(this);
+    }
+
+    // Private
+}

--- a/app/src/main/java/com/money/manager/ex/settings/SettingsFragment.java
+++ b/app/src/main/java/com/money/manager/ex/settings/SettingsFragment.java
@@ -22,10 +22,9 @@ import android.support.v7.preference.Preference;
 import android.support.v7.preference.PreferenceFragmentCompat;
 import android.support.v7.preference.PreferenceScreen;
 import android.text.TextUtils;
+import android.util.Log;
 
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.mikepenz.google_material_typeface_library.GoogleMaterial;
-import com.mikepenz.mmex_icon_font_typeface_library.MMXIconFont;
 import com.money.manager.ex.Constants;
 import com.money.manager.ex.DonateActivity;
 import com.money.manager.ex.R;
@@ -102,6 +101,20 @@ public class SettingsFragment
                 @Override
                 public boolean onPreferenceClick(Preference preference) {
                     startActivity(new Intent(getActivity(), InvestmentSettingsActivity.class));
+                    return true;
+                }
+            });
+        }
+
+        //uiHelper.getIcon(MMXIconFont.Icon.mmx_law) ?
+        final Preference budgetPreference = findPreference(getString(R.string.pref_budget));
+        if (budgetPreference != null) {
+            budgetPreference.setIcon(uiHelper.getIcon(GoogleMaterial.Icon.gmd_toll)
+                    .color(uiHelper.getSecondaryTextColor()));
+            budgetPreference.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+                @Override
+                public boolean onPreferenceClick(Preference preference) {
+                    startActivity(new Intent(getActivity(), BudgetSettingsActivity.class));
                     return true;
                 }
             });

--- a/app/src/main/java/com/money/manager/ex/settings/SettingsFragment.java
+++ b/app/src/main/java/com/money/manager/ex/settings/SettingsFragment.java
@@ -24,6 +24,7 @@ import android.support.v7.preference.PreferenceScreen;
 import android.text.TextUtils;
 
 import com.mikepenz.google_material_typeface_library.GoogleMaterial;
+import com.mikepenz.mmex_icon_font_typeface_library.MMXIconFont;
 import com.money.manager.ex.Constants;
 import com.money.manager.ex.DonateActivity;
 import com.money.manager.ex.R;
@@ -105,10 +106,9 @@ public class SettingsFragment
             });
         }
 
-        //uiHelper.getIcon(MMXIconFont.Icon.mmx_law) ?
         final Preference budgetPreference = findPreference(getString(R.string.pref_budget));
         if (budgetPreference != null) {
-            budgetPreference.setIcon(uiHelper.getIcon(GoogleMaterial.Icon.gmd_local_atm)
+            budgetPreference.setIcon(uiHelper.getIcon(MMXIconFont.Icon.mmx_law)
                     .color(uiHelper.getSecondaryTextColor()));
             budgetPreference.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
                 @Override

--- a/app/src/main/java/com/money/manager/ex/settings/SettingsFragment.java
+++ b/app/src/main/java/com/money/manager/ex/settings/SettingsFragment.java
@@ -22,7 +22,6 @@ import android.support.v7.preference.Preference;
 import android.support.v7.preference.PreferenceFragmentCompat;
 import android.support.v7.preference.PreferenceScreen;
 import android.text.TextUtils;
-import android.util.Log;
 
 import com.mikepenz.google_material_typeface_library.GoogleMaterial;
 import com.money.manager.ex.Constants;
@@ -109,7 +108,7 @@ public class SettingsFragment
         //uiHelper.getIcon(MMXIconFont.Icon.mmx_law) ?
         final Preference budgetPreference = findPreference(getString(R.string.pref_budget));
         if (budgetPreference != null) {
-            budgetPreference.setIcon(uiHelper.getIcon(GoogleMaterial.Icon.gmd_toll)
+            budgetPreference.setIcon(uiHelper.getIcon(GoogleMaterial.Icon.gmd_local_atm)
                     .color(uiHelper.getSecondaryTextColor()));
             budgetPreference.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
                 @Override

--- a/app/src/main/res/layout/item_budget_simple.xml
+++ b/app/src/main/res/layout/item_budget_simple.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2012-2016 The Android Money Manager Ex Project Team
+  ~
+  ~ This program is free software; you can redistribute it and/or
+  ~ modify it under the terms of the GNU General Public License
+  ~ as published by the Free Software Foundation; either version 3
+  ~ of the License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="48dp"
+    android:layout_gravity="center_horizontal"
+    android:orientation="horizontal" >
+
+    <com.money.manager.ex.view.RobotoTextView
+        android:id="@+id/categoryTextView"
+        android:layout_width="0dp"
+        android:padding="4dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="center_vertical"
+        android:gravity="center_vertical"
+        android:layout_weight="1"
+        android:text="@string/category" />
+
+    <com.money.manager.ex.view.RobotoTextView
+        android:id="@+id/amountAvailableTextView"
+        android:layout_width="wrap_content"
+        android:minWidth="60dp"
+        android:padding="4dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="end"
+        android:gravity="center_vertical|end"
+        android:text="@string/amount" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_budget_simple_header.xml
+++ b/app/src/main/res/layout/item_budget_simple_header.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2012-2016 The Android Money Manager Ex Project Team
+  ~
+  ~ This program is free software; you can redistribute it and/or
+  ~ modify it under the terms of the GNU General Public License
+  ~ as published by the Free Software Foundation; either version 3
+  ~ of the License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="48dp"
+    android:layout_gravity="center_horizontal"
+    android:orientation="horizontal" >
+
+    <com.money.manager.ex.view.RobotoTextView
+        android:id="@+id/categoryTextView"
+        android:layout_width="0dp"
+        android:padding="4dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="center_vertical"
+        android:gravity="center_vertical"
+        android:layout_weight="1"
+        android:text="@string/category" />
+
+    <com.money.manager.ex.view.RobotoTextView
+        android:id="@+id/amountTextView"
+        android:layout_width="wrap_content"
+        android:minWidth="60dp"
+        android:padding="4dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="end"
+        android:gravity="center_vertical|end"
+        android:text="@string/amount" />
+
+</LinearLayout>

--- a/app/src/main/res/values/prefids.xml
+++ b/app/src/main/res/values/prefids.xml
@@ -87,6 +87,10 @@
     <string name="pref_investment">pref_investment</string>
     <string name="pref_quote_provider">pref_quote_provider</string>
     <string name="pref_exchange_rate_provider">pref_exchange_rate_provider</string>
+    <!-- budget -->
+    <string name="pref_budget">pref_budgets</string>
+    <string name="pref_budget_show_simple_view">pref_budget_show_simple_view</string>
+    <string name="pref_budget_load_current">pref_budget_load_current</string>
 
     <!-- dropbox / deprecated -->
     <string name="pref_dropbox_download">dropbox2download</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -783,9 +783,7 @@
 
     <string name="save">Save</string>
 
-
-    <string name="title_budget_show_Simple_view">Show simple budget view</string>
-    <string name="summary_budget_show_simple_view">If checked Budgets use the simplified view</string>
-
+    <string name="title_budget_show_simple_view">Show simple budget view</string>
+    <string name="summary_budget_show_simple_view">If checked budgets use the simplified view</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -782,4 +782,10 @@
     <string name="per_database_settings">Per-Database</string>
 
     <string name="save">Save</string>
+
+
+    <string name="title_budget_show_Simple_view">Show simple budget view</string>
+    <string name="summary_budget_show_simple_view">If checked Budgets use the simplified view</string>
+
+
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -42,6 +42,10 @@
         android:title="@string/investment" />
     <Preference
         android:icon="@null"
+        android:key="@string/pref_budget"
+        android:title="@string/budget" />
+    <Preference
+        android:icon="@null"
         android:key="@string/pref_security"
         android:title="@string/preferences_security" />
     <Preference

--- a/app/src/main/res/xml/preferences_budget.xml
+++ b/app/src/main/res/xml/preferences_budget.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2012-2016 The Android Money Manager Ex Project Team
+  ~
+  ~ This program is free software; you can redistribute it and/or
+  ~ modify it under the terms of the GNU General Public License
+  ~ as published by the Free Software Foundation; either version 3
+  ~ of the License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <SwitchPreferenceCompat
+        android:icon="@null"
+        android:defaultValue="false"
+        android:key="@string/pref_budget_show_simple_view"
+        android:summary="@string/summary_budget_show_simple_view"
+        android:title="@string/title_budget_show_Simple_view" />
+
+    <SwitchPreferenceCompat
+        android:icon="@null"
+        android:defaultValue="true"
+        android:key="@string/pref_show_tutorial"
+        android:title="@string/title_show_tutorial"
+        android:summary="@string/summary_show_tutorial" />
+
+</PreferenceScreen>

--- a/app/src/main/res/xml/preferences_budget.xml
+++ b/app/src/main/res/xml/preferences_budget.xml
@@ -22,13 +22,6 @@
         android:defaultValue="false"
         android:key="@string/pref_budget_show_simple_view"
         android:summary="@string/summary_budget_show_simple_view"
-        android:title="@string/title_budget_show_Simple_view" />
-
-    <SwitchPreferenceCompat
-        android:icon="@null"
-        android:defaultValue="true"
-        android:key="@string/pref_show_tutorial"
-        android:title="@string/title_show_tutorial"
-        android:summary="@string/summary_show_tutorial" />
+        android:title="@string/title_budget_show_simple_view" />
 
 </PreferenceScreen>


### PR DESCRIPTION
I've been using Money Manager Ex for months now and I have some ideas to improve the budgeting part.

Changes in this PR:
 - Added coloring for the values in the "Actual" column in budgets whether they are above/below the planned amount.
 - Added a Settings panel for budgets and added a simplified budget view where the frequency is hidden and only the difference of planned and actual amounts are shown. The intention behind this is to reduce the amount of information on this list; hopefully this makes it easier to understand the current status of the cash flow just by glancing on the figures. This is somewhat related to #804.
- Amended BudgetActivity to only use fragment back stack in single panel UI.


 Planned changes:
 - New setting to open the current budget (if exists) when choosing Budgets from the navigation drawer.
 - Ability to edit budget entries.
 - Ability to add transactions to a category straight from a budget.
 - Cache and/or preload the computed amounts for categories in order to make the UI faster.
 - Summary row at the top of a budget with planned and actual expenses/income.

Any feedback is welcome.
