### PR TITLE
fix(#1141): Add support for "N" as a code for "NONE" TransactionStatus

### DIFF
--- a/app/src/main/java/com/money/manager/ex/core/TransactionStatuses.java
+++ b/app/src/main/java/com/money/manager/ex/core/TransactionStatuses.java
@@ -39,6 +39,9 @@ public enum TransactionStatuses {
     }
 
     public static TransactionStatuses get(String code) {
+        if (code.equals("N")) {
+            return TransactionStatuses.NONE;
+        }
         for (TransactionStatuses value : TransactionStatuses.values()) {
             String currentCode = value.getCode();
             if (currentCode.equals(code)) {


### PR DESCRIPTION
It was introduced in desktop MMEx 1.4.x.