### PR TITLE
Fixed issue with writeaheadlogging for Android Pie, I hope.

### DIFF
--- a/app/src/main/java/com/money/manager/ex/database/MmxOpenHelper.java
+++ b/app/src/main/java/com/money/manager/ex/database/MmxOpenHelper.java
@@ -96,6 +96,7 @@ public class MmxOpenHelper
 
         try {
             executeRawSql(db, R.raw.tables_v1);
+            db.disableWriteAheadLogging();
             initDatabase(db);
         } catch (Exception e) {
             Timber.e(e, "initializing database");
@@ -104,6 +105,7 @@ public class MmxOpenHelper
 
     @Override
     public void onOpen(SQLiteDatabase db) {
+        db.disableWriteAheadLogging();
         super.onOpen(db);
 
 //        int version = db.getVersion();


### PR DESCRIPTION
updated MmxOpenHelper.java to always disable write ahead logging before init or open a db.

Tested in an Android Pie Pixel emulator (API 28), to mimic my hardware.  The unchanged program made the WAL and SHM files.

Once I added the 2 lines (before init or open the db), I only saw the .mmb file.  More importantly, the .mmb file sync'd back to Dropbox, and when I picked it up on a tablet running Nougat, the changes I made in Pie were present.

I think that most of the complaints about Pie and sync'ing are probably due to this BIG change in the underlying SQLite engine for Pie...