### PR TITLE
Fix Issue 1254, database does not sync or update on android pie - and makes shm/wal files instead

### DIFF
--- a/app/src/main/java/com/money/manager/ex/database/MmxOpenHelper.java
+++ b/app/src/main/java/com/money/manager/ex/database/MmxOpenHelper.java
@@ -96,6 +96,7 @@ public class MmxOpenHelper
 
         try {
             executeRawSql(db, R.raw.tables_v1);
+            db.disableWriteAheadLogging();
             initDatabase(db);
         } catch (Exception e) {
             Timber.e(e, "initializing database");
@@ -104,6 +105,7 @@ public class MmxOpenHelper
 
     @Override
     public void onOpen(SQLiteDatabase db) {
+        db.disableWriteAheadLogging();
         super.onOpen(db);
 
 //        int version = db.getVersion();


### PR DESCRIPTION
updated MmxOpenHelper.java to always disable write ahead logging before init or open a db.

I've tested this on a Nexus 7 emulator running Android 4.1.  Runs without crashing, creating and opening and adding records to a database.

I've also tested this on a Google Pixel emulator running Android Pie.  Instead of making the wal/shm files, it  updates the .mmb and syncs it to the remote provider, as configured.