### PR TITLE
Fix #1326:  Asset Allocation crashes on open, following androidx upgrade

### DIFF
--- a/app/src/main/res/layout/activity_asset_allocation_overview.xml
+++ b/app/src/main/res/layout/activity_asset_allocation_overview.xml
@@ -54,7 +54,7 @@
                 <!--app:layout_collapseMode="parallax" />-->
 
             <!-- collapsible part above the toolbar -->
-            <android.support.v7.widget.LinearLayoutCompat
+            <androidx.appcompat.widget.LinearLayoutCompat
                 android:layout_width="match_parent"
                 android:layout_height="100dp"
                 android:layout_gravity="bottom|center_horizontal"
@@ -77,9 +77,9 @@
                     android:layout_height="wrap_content"
                     android:gravity="center"
                     android:text="@string/total" />
-            </android.support.v7.widget.LinearLayoutCompat>
+            </androidx.appcompat.widget.LinearLayoutCompat>
 
-            <android.support.v7.widget.Toolbar
+            <androidx.appcompat.widget.Toolbar
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"

--- a/app/src/main/res/layout/activity_budget_edit.xml
+++ b/app/src/main/res/layout/activity_budget_edit.xml
@@ -61,7 +61,7 @@
                 android:scaleType="centerCrop"
                 app:layout_collapseMode="parallax" />
 
-            <android.support.v7.widget.Toolbar
+            <androidx.appcompat.widget.Toolbar
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"

--- a/app/src/main/res/layout/activity_price_edit.xml
+++ b/app/src/main/res/layout/activity_price_edit.xml
@@ -61,7 +61,7 @@
                 android:scaleType="centerCrop"
                 app:layout_collapseMode="parallax" />
 
-            <android.support.v7.widget.Toolbar
+            <androidx.appcompat.widget.Toolbar
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"


### PR DESCRIPTION
Full credits to @funrider1 and @MisterY for the observations and pointers, a big thank you.

Fixes #1326