### PR TITLE
Fix Passcode crash after androidx upgrade

### DIFF
--- a/app/src/main/java/com/money/manager/ex/PasscodeActivity.java
+++ b/app/src/main/java/com/money/manager/ex/PasscodeActivity.java
@@ -20,7 +20,7 @@ import android.Manifest;
 import android.app.KeyguardManager;
 import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.hardware.fingerprint.FingerprintManager;
+import androidx.core.hardware.fingerprint.FingerprintManagerCompat;
 import android.os.Build;
 import android.os.Bundle;
 import androidx.core.app.ActivityCompat;
@@ -75,8 +75,8 @@ public class PasscodeActivity extends AppCompatActivity {
 	private Cipher cipher;
 	private KeyStore keyStore;
 	private KeyGenerator keyGenerator;
-	private FingerprintManager.CryptoObject cryptoObject;
-	private FingerprintManager fingerprintManager;
+	private FingerprintManagerCompat.CryptoObject cryptoObject;
+	private FingerprintManagerCompat fingerprintManager;
 	private KeyguardManager keyguardManager;
 
 	@Override
@@ -161,7 +161,8 @@ public class PasscodeActivity extends AppCompatActivity {
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
 
 			keyguardManager = (KeyguardManager) getSystemService(KEYGUARD_SERVICE);
-			fingerprintManager = (FingerprintManager) getSystemService(FINGERPRINT_SERVICE);
+			//fingerprintManager = (FingerprintManager) getSystemService(FINGERPRINT_SERVICE);
+			fingerprintManager = FingerprintManagerCompat.from(getApplicationContext());
 
 			if (!fingerprintManager.isHardwareDetected()) {
 				((ImageView) findViewById(R.id.fpImageView))
@@ -189,7 +190,7 @@ public class PasscodeActivity extends AppCompatActivity {
 						e.printStackTrace();
 					}
 					if (initCipher()) {
-						cryptoObject = new FingerprintManager.CryptoObject(cipher);
+						cryptoObject = new FingerprintManagerCompat.CryptoObject(cipher);
 						FingerprintHandler helper = new FingerprintHandler(this);
 						helper.startAuth(fingerprintManager, cryptoObject);
 					}

--- a/app/src/main/java/com/money/manager/ex/home/MainActivity.java
+++ b/app/src/main/java/com/money/manager/ex/home/MainActivity.java
@@ -295,7 +295,8 @@ public class MainActivity
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
 
-        if (resultCode != RESULT_OK) return;
+        // don't accidentally bypass passcode (failures), e.g. pressing physical back button
+        if (resultCode != RESULT_OK && requestCode != RequestCodes.PASSCODE) return;
 
         switch (requestCode) {
 //            case RequestCodes.SELECT_FILE:

--- a/app/src/main/java/com/money/manager/ex/passcode/FingerprintHandler.java
+++ b/app/src/main/java/com/money/manager/ex/passcode/FingerprintHandler.java
@@ -8,14 +8,14 @@ import android.content.Context;
 import android.content.Intent;
 import android.Manifest;
 import android.content.pm.PackageManager;
-import android.hardware.fingerprint.FingerprintManager;
-import android.os.CancellationSignal;
+import androidx.core.hardware.fingerprint.FingerprintManagerCompat;
+import androidx.core.os.CancellationSignal;
 import androidx.core.app.ActivityCompat;
 import androidx.appcompat.app.AppCompatActivity;
 import android.widget.Toast;
 import com.money.manager.ex.PasscodeActivity;
 
-public class FingerprintHandler extends FingerprintManager.AuthenticationCallback {
+public class FingerprintHandler extends FingerprintManagerCompat.AuthenticationCallback {
 
     private CancellationSignal cancellationSignal;
     private Context context;
@@ -24,12 +24,12 @@ public class FingerprintHandler extends FingerprintManager.AuthenticationCallbac
         context = mContext;
     }
 
-    public void startAuth(FingerprintManager manager, FingerprintManager.CryptoObject cryptoObject) {
+    public void startAuth(FingerprintManagerCompat manager, FingerprintManagerCompat.CryptoObject cryptoObject) {
         cancellationSignal = new CancellationSignal();
         if (ActivityCompat.checkSelfPermission(context, Manifest.permission.USE_FINGERPRINT) != PackageManager.PERMISSION_GRANTED) {
             return;
         }
-        manager.authenticate(cryptoObject, cancellationSignal, 0, this, null);
+        manager.authenticate(cryptoObject, 0, cancellationSignal, this, null);
     }
 
     @Override
@@ -48,7 +48,7 @@ public class FingerprintHandler extends FingerprintManager.AuthenticationCallbac
     }
 
     @Override
-    public void onAuthenticationSucceeded(FingerprintManager.AuthenticationResult result) {
+    public void onAuthenticationSucceeded(FingerprintManagerCompat.AuthenticationResult result) {
         //Toast.makeText(context, "Authentication Success!", Toast.LENGTH_LONG).show();
 
         Intent data = new Intent();

--- a/app/src/main/res/layout-land/passcode_activity.xml
+++ b/app/src/main/res/layout-land/passcode_activity.xml
@@ -118,6 +118,23 @@
                     android:maxLines="1" />
             </LinearLayout>
         </LinearLayout>
+
+        <ImageView
+            android:layout_width="75dp"
+            android:layout_height="75dp"
+            app:srcCompat="@drawable/fingerprint"
+            android:id="@+id/fpImageView"
+            android:layout_below="@+id/textView"
+            android:layout_centerHorizontal="true"
+            android:layout_marginTop="36dp"/>
+
+        <com.money.manager.ex.view.RobotoTextView
+            android:id="@+id/fingerprintInfo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="@dimen/mmx_text_view_size_small"
+            android:text="@string/fingerprint_info"/>
+
     </LinearLayout>
 
     <LinearLayout


### PR DESCRIPTION
Fix #1279:  Migrate `FingerprintManager` to androidx namespace `FingerprintManagerCompat`

Fix #1293:  Don't accidentally bypass passcode e.g. when pressing hardware 'back' button

TODO:
- actually test if fingerprint works after moving to `FingerprintManagerCompat`:  right now the code compiles and (seemingly) runs without problems.  Actual test would need Android 6.0+ with a fingerprint sensor.

- use the new `BiometricPrompt` API (introduced since Android P).   There's a [handy article](https://proandroiddev.com/5-steps-to-implement-biometric-authentication-in-android-dbeb825aeee8?gi=386855d763ca) on the new api (and falling back to `FingerprintManagerCompat` for older versions);    the author has even made [a library](https://github.com/anitaa1990/Biometric-Auth-Sample) bridging the two apis;    probably useful reading and worth checking out.