### PR TITLE
Replace some deprecated calls

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -186,6 +186,7 @@ dependencies {
     )
     implementation supportDependencies.core
     implementation supportDependencies.support
+    implementation supportDependencies.support_compat  // for androidx.core.text.HtmlCompat
     implementation supportDependencies.appCompat
     implementation supportDependencies.recyclerView
     implementation supportDependencies.cardView

--- a/app/src/main/java/com/money/manager/ex/about/AboutFragment.java
+++ b/app/src/main/java/com/money/manager/ex/about/AboutFragment.java
@@ -20,7 +20,6 @@ package com.money.manager.ex.about;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-import android.text.Html;
 import android.text.TextUtils;
 import android.text.method.LinkMovementMethod;
 import android.view.LayoutInflater;
@@ -39,6 +38,7 @@ import com.money.manager.ex.DonateActivity;
 import com.money.manager.ex.R;
 import com.money.manager.ex.common.MmxBaseFragmentActivity;
 import com.money.manager.ex.core.Core;
+import com.money.manager.ex.core.UIHelper;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -84,7 +84,7 @@ public class AboutFragment extends Fragment {
         // Send Feedback
         TextView txtFeedback = view.findViewById(R.id.textViewLinkFeedback);
         text = "<u>" + txtFeedback.getText() + "</u>";
-        txtFeedback.setText(Html.fromHtml(text));
+        txtFeedback.setText(UIHelper.fromHtml(text));
         txtFeedback.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -104,7 +104,7 @@ public class AboutFragment extends Fragment {
         // rate application
         TextView txtRate = view.findViewById(R.id.textViewLinkRate);
         text = "<u>" + txtRate.getText() + "</u>";
-        txtRate.setText(Html.fromHtml(text));
+        txtRate.setText(UIHelper.fromHtml(text));
         txtRate.setMovementMethod(LinkMovementMethod.getInstance());
         OnClickListenerUrl clickListenerRate = new OnClickListenerUrl();
         clickListenerRate.setUrl("http://play.google.com/store/apps/details?id=com.money.manager.ex");
@@ -113,7 +113,7 @@ public class AboutFragment extends Fragment {
         // application issue tracker
         TextView txtIssues = view.findViewById(R.id.textViewIssuesTracker);
         text = "<u>" + txtIssues.getText() + "</u>";
-        txtIssues.setText(Html.fromHtml(text));
+        txtIssues.setText(UIHelper.fromHtml(text));
         txtIssues.setMovementMethod(LinkMovementMethod.getInstance());
         OnClickListenerUrl clickListenerIssuesTracker = new OnClickListenerUrl();
         clickListenerIssuesTracker.setUrl("https://github.com/moneymanagerex/android-money-manager-ex/issues/");
@@ -122,13 +122,14 @@ public class AboutFragment extends Fragment {
         // MMEX for Android web page
         TextView txtWebsite = view.findViewById(R.id.textViewWebSite);
         text = "<u>" + txtWebsite.getText() + "</u>";
-        String htmlText;
+        /*String htmlText;
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
             htmlText = Html.fromHtml(text, Html.FROM_HTML_MODE_LEGACY).toString();
         } else {
             htmlText = Html.fromHtml(text).toString();
         }
-        txtWebsite.setText(htmlText);
+        txtWebsite.setText(htmlText);*/
+        txtWebsite.setText(UIHelper.fromHtml(text));
         txtWebsite.setMovementMethod(LinkMovementMethod.getInstance());
         OnClickListenerUrl clickListenerWebsite = new OnClickListenerUrl();
         clickListenerWebsite.setUrl("http://android.moneymanagerex.org/");
@@ -137,13 +138,14 @@ public class AboutFragment extends Fragment {
         // report set link
         TextView txtReport = view.findViewById(R.id.textViewLinkWebSite);
         text = "<u>" + txtReport.getText() + "</u>";
-        htmlText = "";
+        /*htmlText = "";
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
             htmlText = Html.fromHtml(text, Html.FROM_HTML_MODE_LEGACY).toString();
         } else {
             htmlText = Html.fromHtml(text).toString();
         }
-        txtReport.setText(htmlText);
+        txtReport.setText(htmlText);*/
+        txtReport.setText(UIHelper.fromHtml(text));
         txtReport.setMovementMethod(LinkMovementMethod.getInstance());
         OnClickListenerUrl clickListenerFeedback = new OnClickListenerUrl();
         clickListenerFeedback.setUrl("http://www.moneymanagerex.org/?utm_campaign=Application_Android&utm_medium=MMEX_" + version + "&utm_source=Website");
@@ -162,14 +164,14 @@ public class AboutFragment extends Fragment {
         // GPLv2 license
         TextView txtLicense = (TextView) view.findViewById(R.id.textViewLicense);
         text = "<u>" + txtLicense.getText() + "</u>";
-        txtLicense.setText(Html.fromHtml(text));
+        txtLicense.setText(UIHelper.fromHtml(text));
         OnClickListenerUrl clickListenerLicense = new OnClickListenerUrl();
         clickListenerLicense.setUrl("http://www.gnu.org/licenses/old-licenses/gpl-2.0.html");
         txtLicense.setOnClickListener(clickListenerLicense);
         // logcat
         TextView txtLogcat = (TextView) view.findViewById(R.id.textViewLogcat);
         text = "<u>" + txtLogcat.getText() + "</u>";
-        txtLogcat.setText(Html.fromHtml(text));
+        txtLogcat.setText(UIHelper.fromHtml(text));
         txtLogcat.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/app/src/main/java/com/money/manager/ex/account/AccountTransactionListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/account/AccountTransactionListFragment.java
@@ -262,20 +262,20 @@ public class AccountTransactionListFragment
             if (!activity.isDualPanel()) {
                 //hide sync toolbar
                 MenuItem itemSync = menu.findItem(R.id.menu_sync);
-                if (itemSync != null) MenuItemCompat.setShowAsAction(itemSync, MenuItem.SHOW_AS_ACTION_IF_ROOM);
+                if (itemSync != null) itemSync.setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM);
 
                 // hide menu open database
                 MenuItem itemOpenDatabase = menu.findItem(R.id.menu_open_database);
                 if (itemOpenDatabase != null) {
                     //itemOpenDatabase.setVisible(isShownOpenDatabaseItemMenu());
-                    MenuItemCompat.setShowAsAction(itemOpenDatabase, !itemSync.isVisible()
+                    itemOpenDatabase.setShowAsAction(!itemSync.isVisible()
                         ? MenuItem.SHOW_AS_ACTION_ALWAYS : MenuItem.SHOW_AS_ACTION_NEVER);
                 }
 
                 //hide dash board
                 MenuItem itemDashboard = menu.findItem(R.id.menu_dashboard);
                 if (itemDashboard != null)
-                    MenuItemCompat.setShowAsAction(itemDashboard, MenuItem.SHOW_AS_ACTION_NEVER);
+                    itemDashboard.setShowAsAction(MenuItem.SHOW_AS_ACTION_NEVER);
             }
         }
 

--- a/app/src/main/java/com/money/manager/ex/adapter/AllDataAdapter.java
+++ b/app/src/main/java/com/money/manager/ex/adapter/AllDataAdapter.java
@@ -20,7 +20,6 @@ import android.content.Context;
 import android.database.Cursor;
 import android.graphics.Color;
 import androidx.core.content.ContextCompat;
-import android.text.Html;
 import android.text.TextUtils;
 import android.util.SparseBooleanArray;
 import android.view.LayoutInflater;
@@ -33,6 +32,7 @@ import com.money.manager.ex.Constants;
 import com.money.manager.ex.MmexApplication;
 import com.money.manager.ex.R;
 import com.money.manager.ex.core.TransactionTypes;
+import com.money.manager.ex.core.UIHelper;
 import com.money.manager.ex.currency.CurrencyService;
 import com.money.manager.ex.database.QueryAllData;
 import com.money.manager.ex.database.QueryBillDeposits;
@@ -215,7 +215,7 @@ public class AllDataAdapter
             // write category/subcategory format html
             if (!TextUtils.isEmpty(categorySub)) {
                 // Display category/sub-category.
-                categorySub = Html.fromHtml(categorySub).toString();
+                categorySub = UIHelper.fromHtml(categorySub).toString();
             } else {
                 // It is either a Transfer or a split category.
                 // then it is a split? todo: improve this check to make it explicit.
@@ -228,7 +228,7 @@ public class AllDataAdapter
 
         // notes
         if (!TextUtils.isEmpty(cursor.getString(cursor.getColumnIndex(NOTES)))) {
-            holder.txtNotes.setText(Html.fromHtml("<small>" + cursor.getString(cursor.getColumnIndex(NOTES)) + "</small>"));
+            holder.txtNotes.setText(UIHelper.fromHtml("<small>" + cursor.getString(cursor.getColumnIndex(NOTES)) + "</small>"));
             holder.txtNotes.setVisibility(View.VISIBLE);
         } else {
             holder.txtNotes.setVisibility(View.GONE);

--- a/app/src/main/java/com/money/manager/ex/adapter/CategoryExpandableListAdapter.java
+++ b/app/src/main/java/com/money/manager/ex/adapter/CategoryExpandableListAdapter.java
@@ -35,6 +35,7 @@ import com.money.manager.ex.domainmodel.Category;
 import java.util.HashMap;
 import java.util.List;
 
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.FragmentActivity;
 
 public class CategoryExpandableListAdapter
@@ -104,7 +105,7 @@ public class CategoryExpandableListAdapter
         holder.text1.setText(entity.getSubcategoryName());
 
         holder.text2.setText(entity.getCategName());
-        holder.text2.setTextColor(getContext().getResources().getColor(android.R.color.darker_gray));
+        holder.text2.setTextColor(ContextCompat.getColor(getContext(), android.R.color.darker_gray));
 
         // Selector. Always hidden on subcategories.
 

--- a/app/src/main/java/com/money/manager/ex/assetallocation/overview/AssetAllocationOverviewActivity.java
+++ b/app/src/main/java/com/money/manager/ex/assetallocation/overview/AssetAllocationOverviewActivity.java
@@ -93,7 +93,7 @@ public class AssetAllocationOverviewActivity
         MenuHelper helper = new MenuHelper(this, menu);
 
         // Edit Asset Allocation.
-        MenuItemCompat.setShowAsAction(helper.add(MenuHelper.edit, R.string.edit, GoogleMaterial.Icon.gmd_edit), MenuItem.SHOW_AS_ACTION_IF_ROOM);
+        helper.add(MenuHelper.edit, R.string.edit, GoogleMaterial.Icon.gmd_edit).setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM);
 
         return true;
     }

--- a/app/src/main/java/com/money/manager/ex/budget/BudgetAdapter.java
+++ b/app/src/main/java/com/money/manager/ex/budget/BudgetAdapter.java
@@ -19,7 +19,6 @@ package com.money.manager.ex.budget;
 import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteQueryBuilder;
-import androidx.core.content.ContextCompat;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -147,11 +146,11 @@ public class BudgetAdapter
             UIHelper uiHelper = new UIHelper(context);
             if ((int) (actual * 100) < (int) (estimated * 100)) {
                 actualTextView.setTextColor(
-                    ContextCompat.getColor(context, uiHelper.resolveAttribute(R.attr.holo_red_color_theme))
+                    uiHelper.getColor(uiHelper.resolveAttribute(R.attr.holo_red_color_theme))
                 );
             } else {
                 actualTextView.setTextColor(
-                    ContextCompat.getColor(context, uiHelper.resolveAttribute(R.attr.holo_green_color_theme))
+                    uiHelper.getColor(uiHelper.resolveAttribute(R.attr.holo_green_color_theme))
                 );
             }
         }
@@ -169,11 +168,11 @@ public class BudgetAdapter
             int amountAvailableInt = (int) (amountAvailable * 100);
             if (amountAvailableInt < 0) {
                 amountAvailableTextView.setTextColor(
-                    ContextCompat.getColor(context, uiHelper.resolveAttribute(R.attr.holo_red_color_theme))
+                    uiHelper.getColor(uiHelper.resolveAttribute(R.attr.holo_red_color_theme))
                 );
             } else if (amountAvailableInt > 0) {
                 amountAvailableTextView.setTextColor(
-                    ContextCompat.getColor(context, uiHelper.resolveAttribute(R.attr.holo_green_color_theme))
+                    uiHelper.getColor(uiHelper.resolveAttribute(R.attr.holo_green_color_theme))
                 );
             }
         }

--- a/app/src/main/java/com/money/manager/ex/common/AmountInputDialog.java
+++ b/app/src/main/java/com/money/manager/ex/common/AmountInputDialog.java
@@ -43,6 +43,7 @@ import net.objecthunter.exp4j.ExpressionBuilder;
 import org.greenrobot.eventbus.EventBus;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.DialogFragment;
 import icepick.Icepick;
 import icepick.State;
@@ -328,7 +329,7 @@ public class AmountInputDialog
                 // Just display the last valid value.
                 displayFormattedAmount();
                 // Use the warning colour.
-                txtTop.setTextColor(getResources().getColor(R.color.material_amber_800));
+                txtTop.setTextColor(ContextCompat.getColor(getContext(), R.color.material_amber_800));
 
                 return false;
             } catch (Exception e) {

--- a/app/src/main/java/com/money/manager/ex/common/BaseExpandableListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/common/BaseExpandableListFragment.java
@@ -122,7 +122,7 @@ public abstract class BaseExpandableListFragment
             // Place an action bar item for searching.
             final MenuItem itemSearch = menu.add(0, R.id.menu_query_mode, 1000, R.string.search);
 
-            MenuItemCompat.setShowAsAction(itemSearch, MenuItem.SHOW_AS_ACTION_ALWAYS);
+            itemSearch.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
 //            ActionBarActivity activity = (ActionBarActivity) getActivity();
 //            AppCompatActivity activity = (AppCompatActivity) getActivity();
 

--- a/app/src/main/java/com/money/manager/ex/common/BaseExpandableListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/common/BaseExpandableListFragment.java
@@ -140,7 +140,7 @@ public abstract class BaseExpandableListFragment
                     }
                 });
                 searchView.setIconified(isMenuItemSearchIconified());
-                MenuItemCompat.setActionView(itemSearch, searchView);
+                itemSearch.setActionView(searchView);
 
                 SearchViewFormatter formatter = new SearchViewFormatter();
 
@@ -183,7 +183,7 @@ public abstract class BaseExpandableListFragment
             edtSearch.requestFocus();
             // rendo visibile la keyboard
             imm.showSoftInput(edtSearch, 0);
-            MenuItemCompat.setActionView(item, searchView);
+            item.setActionView(searchView);
             // aggiorno lo stato
             mDisplayShowCustomEnabled = true;
         } else {
@@ -192,7 +192,7 @@ public abstract class BaseExpandableListFragment
                 // nascondo la keyboard
                 imm.hideSoftInputFromWindow(edtSearch.getWindowToken(), 0);
                 // tolgo la searchview
-                MenuItemCompat.setActionView(item, null);
+                item.setActionView(null);
                 // aggiorno lo stato
                 mDisplayShowCustomEnabled = false;
             } else {

--- a/app/src/main/java/com/money/manager/ex/common/BaseListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/common/BaseListFragment.java
@@ -130,7 +130,7 @@ public abstract class BaseListFragment
             });
 //            searchView.setIconifiedByDefault(isMenuItemSearchIconified());
             searchView.setIconified(isMenuItemSearchIconified());
-            MenuItemCompat.setActionView(itemSearch, searchView);
+            itemSearch.setActionView(searchView);
 
             SearchViewFormatter formatter = new SearchViewFormatter();
             formatter.setSearchIconResource(R.drawable.ic_action_search_dark, true, true);

--- a/app/src/main/java/com/money/manager/ex/common/BaseListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/common/BaseListFragment.java
@@ -114,7 +114,7 @@ public abstract class BaseListFragment
         if (isSearchMenuVisible() && getActivity() != null && getActivity() instanceof AppCompatActivity) {
             // Place an action bar item for searching.
             final MenuItem itemSearch = menu.add(Menu.NONE, R.id.menu_query_mode, 1000, R.string.search);
-            MenuItemCompat.setShowAsAction(itemSearch, MenuItem.SHOW_AS_ACTION_ALWAYS);
+            itemSearch.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
 
             SearchView searchView = new SearchView(getActivity());
             searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {

--- a/app/src/main/java/com/money/manager/ex/common/CalculatorActivity.java
+++ b/app/src/main/java/com/money/manager/ex/common/CalculatorActivity.java
@@ -44,6 +44,7 @@ import net.objecthunter.exp4j.ExpressionBuilder;
 import javax.inject.Inject;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
@@ -185,7 +186,7 @@ public class CalculatorActivity
                 // Just display the last valid value.
                 displayFormattedAmount();
                 // Use the warning colour.
-                txtTop.setTextColor(getResources().getColor(R.color.material_amber_800));
+                txtTop.setTextColor(ContextCompat.getColor(this, R.color.material_amber_800));
 
                 return false;
             } catch (Exception e) {

--- a/app/src/main/java/com/money/manager/ex/core/MenuHelper.java
+++ b/app/src/main/java/com/money/manager/ex/core/MenuHelper.java
@@ -86,7 +86,7 @@ public class MenuHelper {
 
     public void addSaveToolbarIcon() {
         MenuItem item = menu.add(Menu.NONE, save, Menu.NONE, R.string.save);
-        MenuItemCompat.setShowAsAction(item, MenuItem.SHOW_AS_ACTION_ALWAYS);
+        item.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
 
         IconicsDrawable icon = uiHelper.getIcon(GoogleMaterial.Icon.gmd_check)
             //.color(uiHelper.getPrimaryTextColor());

--- a/app/src/main/java/com/money/manager/ex/core/SearchViewFormatter.java
+++ b/app/src/main/java/com/money/manager/ex/core/SearchViewFormatter.java
@@ -150,7 +150,8 @@ public class SearchViewFormatter {
             ImageView imageView = (ImageView) searchView.findViewById(R.id.search_mag_icon);
 
             if (mSearchIconInside) {
-                Drawable searchIconDrawable = mResources.getDrawable(mSearchIconResource);
+                //Drawable searchIconDrawable = mResources.getDrawable(mSearchIconResource);
+                Drawable searchIconDrawable = ContextCompat.getDrawable(searchView.getContext(), mSearchIconResource);
                 int size = (int) (view.getTextSize() * 1.25f);
                 searchIconDrawable.setBounds(0, 0, size, size);
 

--- a/app/src/main/java/com/money/manager/ex/core/SearchViewFormatter.java
+++ b/app/src/main/java/com/money/manager/ex/core/SearchViewFormatter.java
@@ -20,6 +20,8 @@ package com.money.manager.ex.core;
 import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
 import androidx.appcompat.widget.SearchView;
+import androidx.core.content.ContextCompat;
+
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.text.style.ImageSpan;
@@ -134,10 +136,12 @@ public class SearchViewFormatter {
 
         TextView view = (TextView) searchView.findViewById(R.id.search_src_text);
         if (mSearchTextColorResource != 0) {
-            view.setTextColor(mResources.getColor(mSearchTextColorResource));
+            //view.setTextColor(mResources.getColor(mSearchTextColorResource));
+            view.setTextColor(ContextCompat.getColor(searchView.getContext(), mSearchTextColorResource));
         }
         if (mSearchHintColorResource != 0) {
-            view.setHintTextColor(mResources.getColor(mSearchHintColorResource));
+            //view.setHintTextColor(mResources.getColor(mSearchHintColorResource));
+            view.setHintTextColor(ContextCompat.getColor(searchView.getContext(), mSearchHintColorResource));
         }
         if (mInputType > Integer.MIN_VALUE) {
             view.setInputType(mInputType);

--- a/app/src/main/java/com/money/manager/ex/core/UIHelper.java
+++ b/app/src/main/java/com/money/manager/ex/core/UIHelper.java
@@ -19,6 +19,7 @@ package com.money.manager.ex.core;
 
 import android.content.Context;
 import android.content.Intent;
+import android.text.Spanned;
 import android.util.TypedValue;
 import android.widget.Toast;
 
@@ -37,6 +38,7 @@ import javax.inject.Inject;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.ContextCompat;
+import androidx.core.text.HtmlCompat;
 import dagger.Lazy;
 import rx.Observable;
 import rx.Subscriber;
@@ -243,5 +245,24 @@ public class UIHelper {
                 Toast.makeText(getContext(), message, length).show();
             }
         });
+    }
+
+    /**
+     * Convenient method to call HtmlCompat.fromHtml().
+     * Returns HTML string as styled text..
+     * @param text HTML string
+     * @return Spanned
+     */
+    public static Spanned fromHtml(String text) {
+        /*if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+            return Html.fromHtml(text, Html.FROM_HTML_MODE_LEGACY);
+        } else {
+            return Html.fromHtml(text);
+        }*/
+        return HtmlCompat.fromHtml(text, HtmlCompat.FROM_HTML_MODE_LEGACY);
+    }
+
+    public static Spanned fromHtml(String text, int flags) {
+        return HtmlCompat.fromHtml(text, flags);
     }
 }

--- a/app/src/main/java/com/money/manager/ex/database/TransactionStatus.java
+++ b/app/src/main/java/com/money/manager/ex/database/TransactionStatus.java
@@ -24,6 +24,8 @@ import com.money.manager.ex.Constants;
 import com.money.manager.ex.R;
 import com.money.manager.ex.core.TransactionStatuses;
 
+import androidx.core.content.ContextCompat;
+
 /**
  * Helper for transaction status - related issues, like colors, etc.
  * Created by Alessandro Lazzari on 08/09/2014.
@@ -98,19 +100,19 @@ public class TransactionStatus {
 //                result = ctx.getResources().getString(R.string.status_none);
 //                break;
             case RECONCILED:
-                result = ctx.getResources().getColor(R.color.material_green_500);
+                result = ContextCompat.getColor(ctx, R.color.material_green_500);
                 break;
             case VOID:
-                result = ctx.getResources().getColor(R.color.material_red_500);
+                result = ContextCompat.getColor(ctx, R.color.material_red_500);
                 break;
             case FOLLOWUP:
-                result = ctx.getResources().getColor(R.color.material_orange_500);
+                result = ContextCompat.getColor(ctx, R.color.material_orange_500);
                 break;
             case DUPLICATE:
-                result = ctx.getResources().getColor(R.color.material_indigo_500);
+                result = ContextCompat.getColor(ctx, R.color.material_indigo_500);
                 break;
             default:
-                result = ctx.getResources().getColor(R.color.material_grey_500);
+                result = ContextCompat.getColor(ctx, R.color.material_grey_500);
                 break;
         }
         return result;

--- a/app/src/main/java/com/money/manager/ex/home/DashboardFragment.java
+++ b/app/src/main/java/com/money/manager/ex/home/DashboardFragment.java
@@ -23,7 +23,6 @@ import android.database.sqlite.SQLiteQueryBuilder;
 import android.os.Build;
 import android.os.Bundle;
 import androidx.core.content.ContextCompat;
-import android.text.Html;
 import android.text.TextUtils;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -445,7 +444,7 @@ public class DashboardFragment
             if (gravity[i] != null)
                 txtField.setGravity(gravity[i]);
             // set text
-            txtField.setText(Html.fromHtml(fields[i]));
+            txtField.setText(UIHelper.fromHtml(fields[i]));
             // set singleline
             txtField.setSingleLine(true);
             // add field

--- a/app/src/main/java/com/money/manager/ex/home/MainActivity.java
+++ b/app/src/main/java/com/money/manager/ex/home/MainActivity.java
@@ -25,7 +25,6 @@ import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.os.Handler;
 import android.preference.PreferenceManager;
-import android.text.Html;
 import android.text.TextUtils;
 import android.view.KeyEvent;
 import android.view.Menu;
@@ -1346,7 +1345,7 @@ public class MainActivity
 //                    .commit();
             try {
                 Toast.makeText(context,
-                        Html.fromHtml(context.getString(R.string.path_database_using, "<b>" + currentPath + "</b>")),
+                        UIHelper.fromHtml(context.getString(R.string.path_database_using, "<b>" + currentPath + "</b>")),
                         Toast.LENGTH_LONG)
                     .show();
             } catch (Exception e) {

--- a/app/src/main/java/com/money/manager/ex/notifications/RecurringTransactionNotifications.java
+++ b/app/src/main/java/com/money/manager/ex/notifications/RecurringTransactionNotifications.java
@@ -23,10 +23,10 @@ import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
 import androidx.core.app.NotificationCompat;
-import android.text.Html;
 import android.text.TextUtils;
 
 import com.money.manager.ex.R;
+import com.money.manager.ex.core.UIHelper;
 import com.money.manager.ex.currency.CurrencyService;
 import com.money.manager.ex.database.QueryBillDeposits;
 import com.money.manager.ex.recurring.transactions.RecurringTransactionListActivity;
@@ -144,7 +144,7 @@ public class RecurringTransactionNotifications {
                     ": <b>" + currencyService.getCurrencyFormatted(cursor.getInt(cursor.getColumnIndex(QueryBillDeposits.CURRENCYID)),
                     MoneyFactory.fromDouble(cursor.getDouble(cursor.getColumnIndex(QueryBillDeposits.AMOUNT)))) + "</b>";
 
-            result.inboxLine = Html.fromHtml("<small>" + line + "</small>").toString();
+            result.inboxLine = UIHelper.fromHtml("<small>" + line + "</small>").toString();
         }
 
         return result;

--- a/app/src/main/java/com/money/manager/ex/notifications/RecurringTransactionNotifications.java
+++ b/app/src/main/java/com/money/manager/ex/notifications/RecurringTransactionNotifications.java
@@ -32,6 +32,7 @@ import com.money.manager.ex.database.QueryBillDeposits;
 import com.money.manager.ex.recurring.transactions.RecurringTransactionListActivity;
 import com.money.manager.ex.utils.NotificationUtils;
 
+import androidx.core.content.ContextCompat;
 import info.javaperformance.money.MoneyFactory;
 import timber.log.Timber;
 
@@ -113,7 +114,7 @@ public class RecurringTransactionNotifications {
                     .setDefaults(Notification.DEFAULT_VIBRATE | Notification.DEFAULT_SOUND | Notification.DEFAULT_LIGHTS)
                     .setNumber(model.number)
                     .setStyle(inboxStyle)
-                    .setColor(mContext.getResources().getColor(R.color.md_primary))
+                    .setColor(ContextCompat.getColor(mContext, R.color.md_primary))
 //                    .addAction(R.drawable.ic_action_content_clear_dark, getContext().getString(R.string.skip), skipPending)
 //                    .addAction(R.drawable.ic_action_done_dark, getContext().getString(R.string.enter), enterPending)
                     .build();

--- a/app/src/main/java/com/money/manager/ex/notifications/SmsReceiverTransactions.java
+++ b/app/src/main/java/com/money/manager/ex/notifications/SmsReceiverTransactions.java
@@ -64,6 +64,7 @@ import com.squareup.sqlbrite.BriteDatabase;
 
 import javax.inject.Inject;
 
+import androidx.core.content.ContextCompat;
 import info.javaperformance.money.MoneyFactory;
 import timber.log.Timber;
 
@@ -1116,13 +1117,13 @@ public class SmsReceiverTransactions extends BroadcastReceiver {
             // Change the notification color based on the status
             switch(txnStatus){
                 case "Auto Failed":
-                    notification.color = mContext.getResources().getColor(R.color.md_red);
+                    notification.color = ContextCompat.getColor(mContext, R.color.md_red);
                     break;  //optional
                 case "Already Exists":
-                    notification.color = mContext.getResources().getColor(R.color.md_indigo);
+                    notification.color = ContextCompat.getColor(mContext, R.color.md_indigo);
                     break;  //optional
                 default:
-                    notification.color = mContext.getResources().getColor(R.color.md_primary);
+                    notification.color = ContextCompat.getColor(mContext, R.color.md_primary);
             }
 
             // notify

--- a/app/src/main/java/com/money/manager/ex/reports/CategoriesReportAdapter.java
+++ b/app/src/main/java/com/money/manager/ex/reports/CategoriesReportAdapter.java
@@ -19,7 +19,6 @@ package com.money.manager.ex.reports;
 import android.content.Context;
 import android.database.Cursor;
 import androidx.core.content.ContextCompat;
-import android.text.Html;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -68,7 +67,7 @@ public class CategoriesReportAdapter
         } else {
             column1 = "<i>" + context.getString(R.string.empty_category);
         }
-        txtColumn1.setText(Html.fromHtml(column1));
+        txtColumn1.setText(UIHelper.fromHtml(column1));
 
         CurrencyService currencyService = new CurrencyService(mContext);
 

--- a/app/src/main/java/com/money/manager/ex/reports/CategoriesReportAdapter.java
+++ b/app/src/main/java/com/money/manager/ex/reports/CategoriesReportAdapter.java
@@ -18,7 +18,6 @@ package com.money.manager.ex.reports;
 
 import android.content.Context;
 import android.database.Cursor;
-import androidx.core.content.ContextCompat;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -74,9 +73,9 @@ public class CategoriesReportAdapter
         txtColumn2.setText(currencyService.getCurrencyFormatted(currencyService.getBaseCurrencyId(), MoneyFactory.fromDouble(total)));
         UIHelper uiHelper = new UIHelper(context);
         if (total < 0) {
-            txtColumn2.setTextColor(ContextCompat.getColor(context, uiHelper.resolveAttribute(R.attr.holo_red_color_theme)));
+            txtColumn2.setTextColor(uiHelper.getColor(uiHelper.resolveAttribute(R.attr.holo_red_color_theme)));
         } else {
-            txtColumn2.setTextColor(ContextCompat.getColor(context, uiHelper.resolveAttribute(R.attr.holo_green_color_theme)));
+            txtColumn2.setTextColor(uiHelper.getColor(uiHelper.resolveAttribute(R.attr.holo_green_color_theme)));
         }
 
         //view.setBackgroundColor(core.resolveColorAttribute(cursor.getPosition() % 2 == 1 ? R.attr.row_dark_theme : R.attr.row_light_theme));

--- a/app/src/main/java/com/money/manager/ex/reports/IncomeVsExpensesAdapter.java
+++ b/app/src/main/java/com/money/manager/ex/reports/IncomeVsExpensesAdapter.java
@@ -88,10 +88,10 @@ public class IncomeVsExpensesAdapter
 
         UIHelper uiHelper = new UIHelper(context);
         if (income - Math.abs(expenses) < 0) {
-            txtDifference.setTextColor(context.getResources().getColor(
+            txtDifference.setTextColor(uiHelper.getColor(
                 uiHelper.resolveAttribute(R.attr.holo_red_color_theme)));
         } else {
-            txtDifference.setTextColor(context.getResources().getColor(
+            txtDifference.setTextColor(uiHelper.getColor(
                 uiHelper.resolveAttribute(R.attr.holo_green_color_theme)));
         }
         //view.setBackgroundColor(core.resolveColorAttribute(cursor.getPosition() % 2 == 1 ? R.attr.row_dark_theme : R.attr.row_light_theme));

--- a/app/src/main/java/com/money/manager/ex/reports/IncomeVsExpensesChartFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/IncomeVsExpensesChartFragment.java
@@ -81,8 +81,9 @@ public class IncomeVsExpensesChartFragment
         BarDataSet dataSetIncomes = new BarDataSet(yIncomes, getString(R.string.income));
         BarDataSet dataSetExpenses = new BarDataSet(yExpenses, getString(R.string.expenses));
 
-        dataSetExpenses.setColor(getResources().getColor(R.color.material_red_500));
-        dataSetIncomes.setColor(getResources().getColor(R.color.material_green_500));
+        UIHelper uiHelper = new UIHelper(getActivity());
+        dataSetExpenses.setColor(uiHelper.getColor(R.color.material_red_500));
+        dataSetIncomes.setColor(uiHelper.getColor(R.color.material_green_500));
 
         List<IBarDataSet> dataSets = new ArrayList<>();
         dataSets.add(dataSetIncomes);
@@ -90,27 +91,27 @@ public class IncomeVsExpensesChartFragment
 
         BarData data = new BarData(xVals, dataSets);
         if (mTextColor != -1)
-            data.setValueTextColor(getResources().getColor(mTextColor));
+            data.setValueTextColor(uiHelper.getColor(mTextColor));
         mChart.setData(data);
         mChart.animateXY(1500, 1500);
         mChart.invalidate();
 
         Legend l = mChart.getLegend();
         if (l != null && mTextColor != -1)
-            l.setTextColor(getResources().getColor(mTextColor));
+            l.setTextColor(uiHelper.getColor(mTextColor));
 
         // x labels
         XAxis xAxis = mChart.getXAxis();
         if (xAxis != null && mTextColor != -1)
-            xAxis.setTextColor(getResources().getColor(mTextColor));
+            xAxis.setTextColor(uiHelper.getColor(mTextColor));
         // right label
         YAxis yAxis = mChart.getAxisRight();
         if (yAxis != null && mTextColor != -1)
-            yAxis.setTextColor(getResources().getColor(mTextColor));
+            yAxis.setTextColor(uiHelper.getColor(mTextColor));
         // left label
         yAxis = mChart.getAxisLeft();
         if (yAxis != null && mTextColor != -1)
-            yAxis.setTextColor(getResources().getColor(mTextColor));
+            yAxis.setTextColor(uiHelper.getColor(mTextColor));
     }
 
     @Override

--- a/app/src/main/java/com/money/manager/ex/reports/PayeeReportAdapter.java
+++ b/app/src/main/java/com/money/manager/ex/reports/PayeeReportAdapter.java
@@ -18,7 +18,6 @@ package com.money.manager.ex.reports;
 
 import android.content.Context;
 import android.database.Cursor;
-import androidx.core.content.ContextCompat;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -67,9 +66,9 @@ public class PayeeReportAdapter
         Core core = new Core(context);
         UIHelper uiHelper = new UIHelper(context);
         if (total < 0) {
-            txtColumn2.setTextColor(ContextCompat.getColor(context, uiHelper.resolveAttribute(R.attr.holo_red_color_theme)));
+            txtColumn2.setTextColor(uiHelper.getColor(uiHelper.resolveAttribute(R.attr.holo_red_color_theme)));
         } else {
-            txtColumn2.setTextColor(ContextCompat.getColor(context, uiHelper.resolveAttribute(R.attr.holo_green_color_theme)));
+            txtColumn2.setTextColor(uiHelper.getColor(uiHelper.resolveAttribute(R.attr.holo_green_color_theme)));
         }
 
         view.setBackgroundColor(core.resolveColorAttribute(cursor.getPosition() % 2 == 1 ? R.attr.row_dark_theme : R.attr.row_light_theme));

--- a/app/src/main/java/com/money/manager/ex/reports/PieChartFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/PieChartFragment.java
@@ -97,15 +97,16 @@ public class PieChartFragment
 
         ArrayList<Integer> colors = new ArrayList<>();
 
+        UIHelper uiHelper = new UIHelper(getActivity());
         for (int c : COLORS)
-            colors.add(getResources().getColor(c));
+            colors.add(uiHelper.getColor(c));
 
         dataSet.setColors(colors);
         PieData data = new PieData(xVals, dataSet);
         data.setValueFormatter(new PercentFormatter());
 
         if (mTextColor != -1)
-            data.setValueTextColor(getResources().getColor(mTextColor));
+            data.setValueTextColor(uiHelper.getColor(mTextColor));
 
         data.setValueTextSize(11f);
         data.setValueTextColor(Color.WHITE);

--- a/app/src/main/java/com/money/manager/ex/search/SearchActivity.java
+++ b/app/src/main/java/com/money/manager/ex/search/SearchActivity.java
@@ -96,7 +96,7 @@ public class SearchActivity
         // Add Search icon.
         getMenuInflater().inflate(R.menu.menu_search, menu);
         MenuItem item = menu.findItem(R.id.searchMenuItem);
-        MenuItemCompat.setShowAsAction(item, MenuItem.SHOW_AS_ACTION_ALWAYS);
+        item.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
         item.setIcon(ui.getIcon(GoogleMaterial.Icon.gmd_search));
         // show this menu item last
 

--- a/app/src/main/java/com/money/manager/ex/search/SearchParametersFragment.java
+++ b/app/src/main/java/com/money/manager/ex/search/SearchParametersFragment.java
@@ -290,7 +290,7 @@ public class SearchParametersFragment
         // 'Reset' toolbar item
         inflater.inflate(R.menu.menu_clear, menu);
         MenuItem item = menu.findItem(R.id.clearMenuItem);
-        MenuItemCompat.setShowAsAction(item, MenuItem.SHOW_AS_ACTION_ALWAYS);
+        item.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
         item.setIcon(ui.getIcon(GoogleMaterial.Icon.gmd_clear));
 
         super.onCreateOptionsMenu(menu,inflater);

--- a/app/src/main/java/com/money/manager/ex/settings/DatabaseSettingsFragment.java
+++ b/app/src/main/java/com/money/manager/ex/settings/DatabaseSettingsFragment.java
@@ -18,7 +18,6 @@ package com.money.manager.ex.settings;
 
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Bundle;
-import android.text.Html;
 import android.text.InputType;
 import android.text.TextUtils;
 import android.util.Log;
@@ -325,7 +324,7 @@ public class DatabaseSettingsFragment
                     Core core = new Core(getActivity().getApplicationContext());
                     File newDatabases = core.backupDatabase();
                     if (newDatabases != null) {
-                        Toast.makeText(getActivity(), Html.fromHtml(getString(R.string.database_has_been_moved,
+                        Toast.makeText(getActivity(), UIHelper.fromHtml(getString(R.string.database_has_been_moved,
                                 "<b>" + newDatabases.getAbsolutePath() + "</b>")), Toast.LENGTH_LONG).show();
                         //MainActivity.changeDatabase(newDatabases.getAbsolutePath());
                         // update the database file

--- a/app/src/main/java/com/money/manager/ex/sync/SyncNotificationFactory.java
+++ b/app/src/main/java/com/money/manager/ex/sync/SyncNotificationFactory.java
@@ -22,6 +22,7 @@ import android.app.PendingIntent;
 import android.content.Context;
 
 import androidx.core.app.NotificationCompat;
+import androidx.core.content.ContextCompat;
 
 import com.money.manager.ex.R;
 import com.money.manager.ex.core.UIHelper;
@@ -56,7 +57,7 @@ public class SyncNotificationFactory {
                 .setContentText(getContext().getString(R.string.sync_downloading))
                 //.setLargeIcon(BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_action_dropbox_dark))
                 .setSmallIcon(R.drawable.ic_stat_notification)
-                .setColor(getContext().getResources().getColor(R.color.md_primary));
+                .setColor(ContextCompat.getColor(getContext(), R.color.md_primary));
 
         return notification.build();
     }
@@ -84,7 +85,7 @@ public class SyncNotificationFactory {
             .setSmallIcon(R.drawable.ic_stat_notification)
             .setTicker(getContext().getString(R.string.dropbox_file_ready_for_use))
             .setStyle(inboxStyle)
-            .setColor(getContext().getResources().getColor(R.color.md_primary))
+            .setColor(ContextCompat.getColor(getContext(), R.color.md_primary))
             .build();
     }
 
@@ -102,7 +103,7 @@ public class SyncNotificationFactory {
                 .setContentText(getContext().getString(R.string.sync_uploading))
                 //.setLargeIcon(BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_action_dropbox_dark))
                 .setSmallIcon(R.drawable.ic_stat_notification)
-                .setColor(getContext().getResources().getColor(R.color.md_primary));
+                .setColor(ContextCompat.getColor(getContext(), R.color.md_primary));
 
         return notification.build();
     }
@@ -129,7 +130,7 @@ public class SyncNotificationFactory {
                 .setSmallIcon(R.drawable.ic_stat_notification)
                 .setStyle(inboxStyle)
                 .setTicker(getContext().getString(R.string.upload_file_complete))
-                .setColor(getContext().getResources().getColor(R.color.md_primary))
+                .setColor(ContextCompat.getColor(getContext(), R.color.md_primary))
                 .build();
 
         return notification;

--- a/app/src/main/java/com/money/manager/ex/transactions/EditTransactionCommonFunctions.java
+++ b/app/src/main/java/com/money/manager/ex/transactions/EditTransactionCommonFunctions.java
@@ -21,7 +21,6 @@ import android.database.Cursor;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.text.Editable;
-import android.text.Html;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.view.View;
@@ -158,7 +157,7 @@ public class EditTransactionCommonFunctions {
             if (!TextUtils.isEmpty(categoryName)) {
                 this.viewHolder.categoryTextView.setText(categoryName);
                 if (!TextUtils.isEmpty(subCategoryName)) {
-                    this.viewHolder.categoryTextView.setText(Html.fromHtml(
+                    this.viewHolder.categoryTextView.setText(UIHelper.fromHtml(
                             this.viewHolder.categoryTextView.getText() + " : <i>" + subCategoryName + "</i>"));
                 }
             }

--- a/app/src/main/java/com/money/manager/ex/transactions/SplitCategoriesAdapter.java
+++ b/app/src/main/java/com/money/manager/ex/transactions/SplitCategoriesAdapter.java
@@ -37,6 +37,7 @@ import org.greenrobot.eventbus.EventBus;
 import java.util.ArrayList;
 import java.util.List;
 
+import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
 import info.javaperformance.money.Money;
 import info.javaperformance.money.MoneyFactory;
@@ -121,7 +122,7 @@ public class SplitCategoriesAdapter
     }
 
     private void bindTransactionTypeButton(ISplitTransaction split, SplitItemViewHolder viewHolder) {
-        int green;
+        /*int green;
         int red;
         // 15
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
@@ -130,7 +131,9 @@ public class SplitCategoriesAdapter
         } else {
             green = getContext().getResources().getColor(R.color.material_green_700);
             red = getContext().getResources().getColor(R.color.material_red_700);
-        }
+        }*/
+        int green = ContextCompat.getColor(getContext(), R.color.material_green_700);
+        int red = ContextCompat.getColor(getContext(), R.color.material_red_700);
 
         if (split.getTransactionType(transactionType) == TransactionTypes.Withdrawal) {
             // withdrawal

--- a/app/src/main/java/com/money/manager/ex/utils/DonateDialogUtils.java
+++ b/app/src/main/java/com/money/manager/ex/utils/DonateDialogUtils.java
@@ -21,7 +21,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
-import android.text.Html;
 import android.text.TextUtils;
 
 import com.afollestad.materialdialogs.DialogAction;
@@ -29,6 +28,7 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import com.money.manager.ex.DonateActivity;
 import com.money.manager.ex.R;
 import com.money.manager.ex.core.InfoKeys;
+import com.money.manager.ex.core.UIHelper;
 import com.money.manager.ex.servicelayer.InfoService;
 import com.money.manager.ex.core.Core;
 import com.money.manager.ex.settings.PreferenceConstants;
@@ -63,7 +63,7 @@ public class DonateDialogUtils {
                     .cancelable(false)
                     .title(R.string.donate)
                     .iconRes(R.mipmap.ic_launcher)
-                    .content(Html.fromHtml(donateText))
+                    .content(UIHelper.fromHtml(donateText))
                     .negativeText(R.string.no_thanks)
                     .onNegative(new MaterialDialog.SingleButtonCallback() {
                         @Override

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ ext {
     supportDependencies = [
             core             : "androidx.legacy:legacy-support-core-utils:${supportLibrary}",
             support          : "androidx.legacy:legacy-support-v4:${supportLibrary}",
-            support_compat   : "com.android.support:support-compat:${supportLibrary}",
+            support_compat   : "androidx.core:core:${supportLibrary}",  // for androidx.core.text.HtmlCompat
             appCompat        : "androidx.appcompat:appcompat:${supportLibrary}",
             cardView         : "androidx.cardview:cardview:${supportLibrary}",
             design           : "com.google.android.material:material:${supportLibrary}",


### PR DESCRIPTION
Replaced some (relatively) straightforward ones to resolve compiler `[deprecation]` warnings:
- `Html.fromHtml(String)` with `HtmlCompat.fromHtml(String, HtmlCompat.FROM_HTML_MODE_LEGACY)` (through a helper function in `UIHelper`)
- static `MenuItemCompat` calls `setShowAsAction` and `setActionView` `(item, ...)` with direct calls to `item` .`setShowAsAction`|`setActionView` `(...)`
- `getColor` and `getDrawable` calls to Resources with ContextCompat calls