### PR TITLE
Notification Management & Recurring Transaction

### DIFF
--- a/app/src/main/java/com/money/manager/ex/home/MainActivity.java
+++ b/app/src/main/java/com/money/manager/ex/home/MainActivity.java
@@ -1248,6 +1248,7 @@ public class MainActivity
         Intent serviceRepeatingTransaction = new Intent(getApplicationContext(), RecurringTransactionBootReceiver.class);
         getApplicationContext().sendBroadcast(serviceRepeatingTransaction);
 
+        /*   // EP Remove from start intent and set in notification management
         if (!autoExecution) return;
 
         QueryBillDeposits billDeposits = new QueryBillDeposits(getApplicationContext());
@@ -1288,7 +1289,7 @@ public class MainActivity
             }
         }
         cursor.close();
-
+        */
         // TODO persist
     }
 

--- a/app/src/main/java/com/money/manager/ex/notifications/RecurringTransactionNotifications.java
+++ b/app/src/main/java/com/money/manager/ex/notifications/RecurringTransactionNotifications.java
@@ -39,7 +39,7 @@ import timber.log.Timber;
 
 public class RecurringTransactionNotifications {
 
-    // Notification channel definition will be move into NotificationUtils to centralize loghic
+    // Notification channel definition will be move into NotificationUtils to centralize logic
     // public static String CHANNEL_ID = "RecurringTransaction_NotificationChannel";
     private static final int ID_NOTIFICATION = 0x000A;
 
@@ -81,53 +81,71 @@ public class RecurringTransactionNotifications {
     }
 
     private void showNotification(SyncNotificationModel model) {
-        NotificationCompat.InboxStyle inboxStyle = new NotificationCompat.InboxStyle();
-        for ( String line: model.inboxLine ) {
-            inboxStyle.addLine(line);
-        }
+        for ( SyncNotificationModel.SyncNotificationModelSingle schedTrx: model.notifications ) {
+            NotificationCompat.InboxStyle inboxStyle = new NotificationCompat.InboxStyle();
 
-        NotificationManager notificationManager = (NotificationManager) getContext()
-                .getSystemService(Context.NOTIFICATION_SERVICE);
+            inboxStyle.addLine(schedTrx.inboxLine);
 
-        // create pending intent
-        Intent intent = new Intent(getContext(), RecurringTransactionListActivity.class);
-        // set launch from notification // check pin code
-        intent.putExtra(RecurringTransactionListActivity.INTENT_EXTRA_LAUNCH_NOTIFICATION, true);
+            NotificationManager notificationManager = (NotificationManager) getContext()
+                    .getSystemService(Context.NOTIFICATION_SERVICE);
 
-        PendingIntent pendingIntent = PendingIntent.getActivity(getContext(), 0, intent, PendingIntent.FLAG_IMMUTABLE);
+/*            Intent showIntent = new Intent(getContext(), RecurringTransactionListActivity.class);
+            // set launch from notification // check pin code
+//            intent.putExtra(RecurringTransactionListActivity.INTENT_EXTRA_LAUNCH_NOTIFICATION, true);
+            showIntent.setAction("SHOW/"+schedTrx.trxId);
+            showIntent.putExtra("ACTION", "SHOW");
+            showIntent.putExtra("ID", schedTrx.trxId);
+            PendingIntent showPending = PendingIntent.getActivity(getContext(), 0, showIntent, PendingIntent.FLAG_IMMUTABLE);
+*/
 
-        // todo: Actions
-//        Intent skipIntent = new Intent(intent);
+            // todo: Actions
+            Intent skipIntent = new Intent(getContext(), RecurringTransactionListActivity.class);
+//            skipIntent.putExtra(RecurringTransactionListActivity.INTENT_EXTRA_LAUNCH_NOTIFICATION, true);
+            skipIntent.setAction("SKIP/"+schedTrx.trxId);
+            skipIntent.putExtra( "ACTION", "SKIP");
+            skipIntent.putExtra("ID", schedTrx.trxId);
+            PendingIntent skipPending = PendingIntent.getActivity(getContext(), 0, skipIntent, PendingIntent.FLAG_IMMUTABLE);
+
+            Intent enterIntent = new Intent(getContext(), RecurringTransactionListActivity.class);
+//            enterIntent.putExtra(RecurringTransactionListActivity.INTENT_EXTRA_LAUNCH_NOTIFICATION, true);
+            enterIntent.setAction("ENTER/"+schedTrx.trxId);
+            enterIntent.putExtra( "ACTION", "ENTER");
+            enterIntent.putExtra("ID", schedTrx.trxId);
+            PendingIntent enterPending = PendingIntent.getActivity(getContext(), 0, enterIntent, PendingIntent.FLAG_IMMUTABLE);
+
+//          Intent skipIntent = new Intent(intent);
 //        //skipIntent.setAction(Intent.)
-//        PendingIntent skipPending = PendingIntent.getActivity(getContext(), 0, skipIntent, 0);
+//          PendingIntent skipPending = PendingIntent.getActivity(getContext(), 0, skipIntent, 0);
 //        Intent enterIntent = new Intent(getContext(), RecurringTransactionEditActivity.class);
 //        PendingIntent enterPending = PendingIntent.getActivity(getContext(), 0, enterIntent, 0);
 
-        // create notification
-        try {
-            NotificationUtils.createNotificationChannel(getContext(), NotificationUtils.CHANNEL_ID_RECURRING);
+            // create notification
+            try {
+                NotificationUtils.createNotificationChannel(getContext(), NotificationUtils.CHANNEL_ID_RECURRING);
 
-            Notification notification = new NotificationCompat.Builder(getContext(), NotificationUtils.CHANNEL_ID_RECURRING)
-                    .setAutoCancel(true)
-                    .setContentIntent(pendingIntent)
-                    .setContentTitle(mContext.getString(R.string.application_name))
-                    .setContentText(mContext.getString(R.string.notification_repeating_transaction_expired))
-                    .setSubText(mContext.getString(R.string.notification_click_to_check_repeating_transaction))
-                    .setSmallIcon(R.drawable.ic_stat_notification)
-                    .setTicker(mContext.getString(R.string.notification_repeating_transaction_expired))
-                    .setDefaults(Notification.DEFAULT_VIBRATE | Notification.DEFAULT_SOUND | Notification.DEFAULT_LIGHTS)
-                    .setNumber(model.number)
-                    .setStyle(inboxStyle)
-                    .setColor(mContext.getResources().getColor(R.color.md_primary))
-//                    .addAction(R.drawable.ic_action_content_clear_dark, getContext().getString(R.string.skip), skipPending)
-//                    .addAction(R.drawable.ic_action_done_dark, getContext().getString(R.string.enter), enterPending)
-                    .build();
+                Notification notification = new NotificationCompat.Builder(getContext(), NotificationUtils.CHANNEL_ID_RECURRING)
+                        .setAutoCancel(true)
+                        .setSmallIcon(R.drawable.ic_stat_notification)
+                        .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+//                        .setContentIntent(pendingIntent)
+                        .setContentTitle(mContext.getString(R.string.application_name))
+                        .setContentText(mContext.getString(R.string.notification_repeating_transaction_expired))
+                        .setContentText(schedTrx.inboxLine)
+//                        .setSubText(mContext.getString(R.strisTE | Notification.DEFAULT_SOUND | Notification.DEFAULT_LIGHTS)
+//                        .setNumber(model.number)
+                        .setStyle(new NotificationCompat.BigTextStyle().bigText(schedTrx.inboxLine))
+                        .setColor(mContext.getResources().getColor(R.color.md_primary))
+                        .addAction(R.drawable.ic_action_content_clear_dark, getContext().getString(R.string.skip), skipPending)
+                        .addAction(R.drawable.ic_action_done_dark, getContext().getString(R.string.enter), enterPending)
+//                        .addAction(R.drawable.ic_action_list_dark , getContext().getString(R.string.show ), showPending)
+                        .build();
 
-            // notify
-            notificationManager.cancel(ID_NOTIFICATION);
-            notificationManager.notify(ID_NOTIFICATION, notification);
-        } catch (Exception e) {
-            Timber.e(e, "showing notification for recurring transaction");
+                // notify
+                notificationManager.cancel(schedTrx.trxId);
+                notificationManager.notify(schedTrx.trxId, notification);
+            } catch (Exception e) {
+                Timber.e(e, "showing notification for recurring transaction");
+            }
         }
     }
 
@@ -151,11 +169,14 @@ public class RecurringTransactionNotifications {
             // compose text
             String line = cursor.getString(cursor.getColumnIndex(QueryBillDeposits.NEXTOCCURRENCEDATE)) +
                     " " + payeeName +
-                    ": <b>" + currencyService.getCurrencyFormatted(cursor.getInt(cursor.getColumnIndex(QueryBillDeposits.CURRENCYID)),
+                    ": " + currencyService.getCurrencyFormatted(cursor.getInt(cursor.getColumnIndex(QueryBillDeposits.CURRENCYID)),
                     MoneyFactory.fromDouble(cursor.getDouble(cursor.getColumnIndex(QueryBillDeposits.AMOUNT)))) +
-                    "</b> (" + Recurrence.recurringModeString( recurringMode ) + ")";
+                    " (" + Recurrence.recurringModeString( recurringMode ) + ")";
 
-            result.inboxLine.add( Html.fromHtml("<small>" + line + "</small>").toString());
+//            result.inboxLine.add( Html.fromHtml("<small>" + line + "</small>").toString());
+            result.addNotification(  line ,
+                    Recurrence.recurringModeString( recurringMode ), cursor.getInt(cursor.getColumnIndex(QueryBillDeposits.BDID)));
+
         }
 
         return result;

--- a/app/src/main/java/com/money/manager/ex/notifications/SyncNotificationModel.java
+++ b/app/src/main/java/com/money/manager/ex/notifications/SyncNotificationModel.java
@@ -26,5 +26,23 @@ import java.util.List;
 
 public class SyncNotificationModel {
     public int number;
-    public List<String> inboxLine = new ArrayList<String>();;
+    // public List<String> inboxLine = new ArrayList<String>();;
+    public List<SyncNotificationModelSingle> notifications = new ArrayList<SyncNotificationModelSingle>();;
+
+    public static class SyncNotificationModelSingle  {
+        String inboxLine ;
+        String mode;
+        int trxId;
+
+        public SyncNotificationModelSingle (String inboxLine, String mode, int trxId) {
+            this.inboxLine = inboxLine;
+            this.mode = mode;
+            this.trxId = trxId;
+        }
+    }
+
+    public void addNotification(String inboxLine, String mode, Integer trxId) {
+        notifications.add(new SyncNotificationModelSingle(inboxLine, mode, trxId));
+    }
+
 }

--- a/app/src/main/java/com/money/manager/ex/recurring/transactions/RecurringTransactionListActivity.java
+++ b/app/src/main/java/com/money/manager/ex/recurring/transactions/RecurringTransactionListActivity.java
@@ -16,6 +16,8 @@
  */
 package com.money.manager.ex.recurring.transactions;
 
+import android.app.NotificationManager;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.widget.Toast;
@@ -44,8 +46,13 @@ public class RecurringTransactionListActivity
         super.onCreate(savedInstanceState);
         setContentView(R.layout.base_toolbar_activity);
 
+        Integer trxid = 0;
+        String action = "";
+
         // check if launch from notification
-        if (getIntent() != null && getIntent().getBooleanExtra(INTENT_EXTRA_LAUNCH_NOTIFICATION, false)) {
+        if (getIntent() != null ) { // && getIntent().getBooleanExtra(INTENT_EXTRA_LAUNCH_NOTIFICATION, false)) {
+            action = getIntent().getStringExtra("ACTION");
+            trxid = getIntent().getIntExtra("ID", 0);
             Passcode passcode = new Passcode(getApplicationContext());
             if (passcode.hasPasscode()) {
                 Intent intent = new Intent(this, PasscodeActivity.class);
@@ -55,6 +62,17 @@ public class RecurringTransactionListActivity
                 // start activity
                 startActivityForResult(intent, INTENT_REQUEST_PASSCODE);
             }
+            if ( action.equals("SKIP") || action.equals("ENTER")) {
+                // ToDo Skip or enter Occurrence
+                NotificationManager notificationManager = (NotificationManager) getApplication().getApplicationContext()
+                        .getSystemService(Context.NOTIFICATION_SERVICE);
+
+                notificationManager.cancel(trxid);
+
+                return;
+
+            }
+
         }
         // set actionbar
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);

--- a/app/src/main/java/com/money/manager/ex/recurring/transactions/RecurringTransactionListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/recurring/transactions/RecurringTransactionListFragment.java
@@ -111,6 +111,7 @@ public class RecurringTransactionListFragment
         // show floating button.
         setFloatingActionButtonVisible(true);
         attachFloatingActionButtonToListView();
+
     }
 
     @Override
@@ -120,6 +121,7 @@ public class RecurringTransactionListFragment
         MmexApplication.getApp().iocComponent.inject(this);
 
         setHasOptionsMenu(true);
+        Intent i = getActivity().getParentActivityIntent();
     }
 
     @Override

--- a/app/src/main/java/com/money/manager/ex/servicelayer/RecurringTransactionService.java
+++ b/app/src/main/java/com/money/manager/ex/servicelayer/RecurringTransactionService.java
@@ -21,12 +21,17 @@ import android.database.Cursor;
 import android.util.Log;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+
 import com.money.manager.ex.Constants;
 import com.money.manager.ex.R;
+import com.money.manager.ex.core.TransactionTypes;
 import com.money.manager.ex.core.UIHelper;
 import com.money.manager.ex.database.ISplitTransaction;
+import com.money.manager.ex.datalayer.AccountTransactionRepository;
 import com.money.manager.ex.datalayer.RecurringTransactionRepository;
 import com.money.manager.ex.datalayer.SplitRecurringCategoriesRepository;
+import com.money.manager.ex.domainmodel.AccountTransaction;
 import com.money.manager.ex.domainmodel.RecurringTransaction;
 import com.money.manager.ex.domainmodel.SplitRecurringCategory;
 import com.money.manager.ex.recurring.transactions.Recurrence;
@@ -440,4 +445,27 @@ public class RecurringTransactionService
             tx.setDueDate(newDueDate);
         }
     }
+
+    public AccountTransaction getAccountTransactionFromRecurring () {
+        RecurringTransactionRepository scheduledRepo = new RecurringTransactionRepository(this.getContext());
+        RecurringTransaction scheduledTrx = scheduledRepo.load(recurringTransactionId);
+        return (scheduledTrx == null) ? null : getAccountTransactionFromRecurring( scheduledTrx ) ;
+    }
+    public AccountTransaction getAccountTransactionFromRecurring (@NonNull RecurringTransaction scheduledTrx) {
+        AccountTransaction accountTrx = AccountTransaction.create();
+        accountTrx.setDate(scheduledTrx.getPaymentDate());
+        accountTrx.setAccountId(scheduledTrx.getAccountId());
+        accountTrx.setAccountToId(scheduledTrx.getToAccountId());
+        accountTrx.setTransactionType(TransactionTypes.valueOf(scheduledTrx.getTransactionCode()));
+        accountTrx.setStatus(scheduledTrx.getStatus());
+        accountTrx.setAmount(scheduledTrx.getAmount());
+        accountTrx.setAmountTo(scheduledTrx.getAmountTo());
+        accountTrx.setPayeeId(scheduledTrx.getPayeeId());
+        accountTrx.setCategoryId(scheduledTrx.getCategoryId());
+        accountTrx.setTransactionNumber(scheduledTrx.getTransactionNumber());
+        accountTrx.setNotes(scheduledTrx.getNotes());
+
+        return  accountTrx;
+    }
+
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -806,6 +806,7 @@
     <string name="notification_channel_fileoperation_uploadin">Mmex Uploading</string>
     <string name="notification_channel_fileoperation_complete">Mmex Upload Complete</string>
     <string name="notification_channel_fileoperation_conflict">Mmex Sync Conflict</string>
+    <string name="show">Show</string>
 
 
 </resources>

--- a/docs/usermanual/index.md
+++ b/docs/usermanual/index.md
@@ -13,6 +13,7 @@ Welcome to the user manual for Money Manager Ex - Android, a free, open-source, 
     - [Reports](#reports)
     - [Data Sync](#data-sync)
     - [Security](#security)
+    - [Recurring Transactions](#recurring-transactions)
 4. [How to Use](#how-to-use)
     - [Adding Transactions](#adding-transactions)
     - [Creating Budgets](#creating-budgets)
@@ -54,6 +55,10 @@ Sync your financial data across multiple devices using cloud synchronization. En
 ### Security
 
 Protect your financial information with advanced security features, including password protection and data encryption.
+
+### Recurring Transactions 
+
+Support for recurring and schedule transactions. Recurring can be Manual, Prompt (with notifications) or Automatic (controlled by setting switch)
 
 ## How to Use
 


### PR DESCRIPTION
Improvement:
- move automatic creation of recurring transaction from MainActivity to RecurringTransactionNotification
- Setup Multiple Notification (one for every Transaction) with contextual Action (Enter or Skip) and press action (Show Recurring Transaction)
- If RecurringTransaction is Auto and AutomaticExecution is **on**, the schedule transaction is immediately executed. Notification has no action
- If RecurringTransaction is Auto and AutomaticExecution is **off**, the schedule transaction is **not** immediately executed. Notification has action to Skip or Enter transaction
- If RecurringTransaction is Prompt or Manual the schedule transaction is **not** immediately executed. Notification has action to Skip or Enter transaction

From a strictly point of view If mode is Manual, there is no need to have notification, bu for me, in android app make sense to have also notification, so there is no real differnce beetween Manual and Prompt. Let me know if is better to remove Manual transaction from notification.

Know issue (I don't know how to solve):
- Every time you press notification a new layer of Schedule transaction is open, so you need to back many time
- Enter action is better to perform open showCreateTransactionActivity(trxid) instead of autopost.

![image](https://github.com/user-attachments/assets/f7c5c805-eed5-42e4-8f84-9cd5bb7e431b)
