### PR TITLE
Hide the reconcilied amount also in the AccountTransactionList

### DIFF
--- a/app/src/main/java/com/money/manager/ex/account/AccountTransactionListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/account/AccountTransactionListFragment.java
@@ -510,6 +510,7 @@ public class AccountTransactionListFragment
         // take reference text view from layout
         this.viewHolder.txtAccountBalance = this.viewHolder.listHeader.findViewById(R.id.textViewAccountBalance);
         this.viewHolder.txtAccountReconciled = this.viewHolder.listHeader.findViewById(R.id.textViewAccountReconciled);
+        this.viewHolder.txtAccountReconciledTitle = this.viewHolder.listHeader.findViewById(R.id.textViewAccountReconciledTitle);
         this.viewHolder.txtAccountDifference = this.viewHolder.listHeader.findViewById(R.id.textViewDifference);
         // favorite icon
         this.viewHolder.imgAccountFav = this.viewHolder.listHeader.findViewById(R.id.imageViewAccountFav);
@@ -879,12 +880,21 @@ public class AccountTransactionListFragment
     }
 
     private void refreshSettings() {
-        mSortTransactionsByType = new AppSettings(getActivity()).getLookAndFeelSettings().getSortTransactionsByType();
+        LookAndFeelSettings mLookAndFeelSettings = new AppSettings(getActivity()).getLookAndFeelSettings();
+        mSortTransactionsByType = mLookAndFeelSettings.getSortTransactionsByType();
+        boolean mHideReconciled = mLookAndFeelSettings.getHideReconciledAmounts();
 
         updateFilterDateRange();
         updateAllDataListFragmentShowBalance();
 
         getActivity().invalidateOptionsMenu();
+
+        if (this.viewHolder.txtAccountReconciled != null) {
+            this.viewHolder.txtAccountReconciled.setVisibility(mHideReconciled ? View.GONE : View.VISIBLE);
+        }
+        if (this.viewHolder.txtAccountReconciledTitle != null) {
+            this.viewHolder.txtAccountReconciledTitle.setVisibility(mHideReconciled ? View.GONE : View.VISIBLE);
+        }
     }
 
     private void updateFilterDateRange() {

--- a/app/src/main/java/com/money/manager/ex/account/AccountTransactionsListViewHolder.java
+++ b/app/src/main/java/com/money/manager/ex/account/AccountTransactionsListViewHolder.java
@@ -26,6 +26,7 @@ import android.widget.TextView;
 public class AccountTransactionsListViewHolder {
     public TextView txtAccountBalance;
     public TextView txtAccountReconciled;
+    public TextView txtAccountReconciledTitle;
     public TextView  txtAccountDifference;
     public ImageView imgAccountFav;
     public ImageView imgGotoAccount;

--- a/app/src/main/res/layout-land/merge_header_fragment_account.xml
+++ b/app/src/main/res/layout-land/merge_header_fragment_account.xml
@@ -43,6 +43,7 @@
 
     <!-- Reconciled Balance title -->
     <com.money.manager.ex.view.RobotoTextView
+        android:id="@+id/textViewAccountReconciledTitle"
         style="@style/Money.TextView.Body2.Inverse"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout-sw600dp-land/merge_header_fragment_account.xml
+++ b/app/src/main/res/layout-sw600dp-land/merge_header_fragment_account.xml
@@ -47,6 +47,7 @@
         android:layout_marginStart="2dp" />
 
     <com.money.manager.ex.view.RobotoTextView
+        android:id="@+id/textViewAccountReconciledTitle"
         style="@style/Money.TextView.Body2.Inverse"
         android:layout_width="128dp"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/merge_header_fragment_account.xml
+++ b/app/src/main/res/layout/merge_header_fragment_account.xml
@@ -52,6 +52,7 @@
     <TableRow>
 
         <com.money.manager.ex.view.RobotoTextView
+            android:id="@+id/textViewAccountReconciledTitle"
             style="@style/Money.TextView.Body2.Inverse"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
The reconcilied amount was shown in AccountTransactionList even when set to Hide in the settings.

This Commit fixes this gap.

Tested on my smartphone only.

As the current master branch does not work (cannot create account or open database), I tested this commit on the last release tag.