### PR TITLE
Refactor for Notification & Autopost switch

### DIFF
--- a/app/src/main/java/com/money/manager/ex/core/RecurringTransactionBootReceiver.java
+++ b/app/src/main/java/com/money/manager/ex/core/RecurringTransactionBootReceiver.java
@@ -49,7 +49,7 @@ public class RecurringTransactionBootReceiver
     private void setAlarm(Context context) {
         BehaviourSettings settings = new BehaviourSettings(context);
 
-        boolean notify = settings.getNotificationRecurringTransaction();
+        boolean notify = settings.getProcessRecurringTransaction();
         if (!notify) return;
 
         // compose intent

--- a/app/src/main/java/com/money/manager/ex/home/MainActivity.java
+++ b/app/src/main/java/com/money/manager/ex/home/MainActivity.java
@@ -84,7 +84,7 @@ import com.money.manager.ex.home.events.RequestWatchlistFragmentEvent;
 import com.money.manager.ex.home.events.UsernameLoadedEvent;
 import com.money.manager.ex.investment.PortfolioFragment;
 import com.money.manager.ex.investment.watchlist.WatchlistFragment;
-import com.money.manager.ex.notifications.RecurringTransactionNotifications;
+import com.money.manager.ex.notifications.RecurringTransactionProcess;
 import com.money.manager.ex.recurring.transactions.RecurringTransactionListFragment;
 import com.money.manager.ex.reports.CategoriesReportActivity;
 import com.money.manager.ex.reports.IncomeVsExpensesActivity;
@@ -1185,13 +1185,13 @@ public class MainActivity
 
     private void populateScheduledTransactions() {
         // start notification & execution for scheduled transaction
-        boolean showNotification = false;
+        boolean processRecurringTransaction = false;
         if (!isScheduledTransactionStarted) {
             AppSettings settings = new AppSettings(this);
-            showNotification = settings.getBehaviourSettings().getNotificationRecurringTransaction();
-            if (showNotification) {
-                RecurringTransactionNotifications notifications = new RecurringTransactionNotifications(this);
-                notifications.notifyRepeatingTransaction();
+            processRecurringTransaction = settings.getBehaviourSettings().getProcessRecurringTransaction();
+            if (processRecurringTransaction) {
+                RecurringTransactionProcess notifications = new RecurringTransactionProcess(this);
+                notifications.processRepeatingTransaction();
                 isScheduledTransactionStarted = true;
             }
         }

--- a/app/src/main/java/com/money/manager/ex/notifications/RecurringTransactionProcess.java
+++ b/app/src/main/java/com/money/manager/ex/notifications/RecurringTransactionProcess.java
@@ -24,7 +24,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
 import androidx.core.app.NotificationCompat;
-import android.text.Html;
+
 import android.text.TextUtils;
 
 import com.money.manager.ex.R;
@@ -41,28 +41,28 @@ import com.money.manager.ex.utils.NotificationUtils;
 import info.javaperformance.money.MoneyFactory;
 import timber.log.Timber;
 
-public class RecurringTransactionNotifications {
+public class RecurringTransactionProcess {
 
     // Notification channel definition will be move into NotificationUtils to centralize logic
     // public static String CHANNEL_ID = "RecurringTransaction_NotificationChannel";
     private static final int ID_NOTIFICATION = 0x000A;
 
-    public RecurringTransactionNotifications(Context context) {
+    public RecurringTransactionProcess(Context context) {
         super();
         mContext = context.getApplicationContext();
     }
 
     private final Context mContext;
 
-    public void notifyRepeatingTransaction() {
+    public void processRepeatingTransaction() {
         try {
-            notifyRepeatingTransaction_Internal();
+            processRepeatingTransaction_Internal();
         } catch (Exception ex) {
             Timber.e(ex, "showing notification about recurring transactions");
         }
     }
 
-    private void notifyRepeatingTransaction_Internal() {
+    private void processRepeatingTransaction_Internal() {
         QueryBillDeposits billDeposits = new QueryBillDeposits(mContext);
 
         /*
@@ -86,13 +86,16 @@ public class RecurringTransactionNotifications {
 
     private void showNotification(SyncNotificationModel model) {
         AppSettings settings = new AppSettings(this.getContext());
-        boolean autoExecution = settings.getBehaviourSettings().getExecutionScheduledTransaction();
 
         for ( SyncNotificationModel.SyncNotificationModelSingle schedTrx: model.notifications ) {
 
-//            NotificationCompat.InboxStyle inboxStyle = new NotificationCompat.InboxStyle();
+            // if mode is manual, skip notification in according with transaction setting
+            if (schedTrx.mode.equals("M")) {
+                continue;
+            }
 
-            if (schedTrx.mode.equals("A") && autoExecution) {
+            // if auto enter transaction (and show info notification)
+            if (schedTrx.mode.equals("A")) {
                 schedTrx.inboxLine = schedTrx.inboxLine.concat(" (AutoExecuted)");
                 RecurringTransactionService service = new RecurringTransactionService(schedTrx.trxId, this.getContext());
                 AccountTransactionRepository accountTransactionRepository = new AccountTransactionRepository( this.getContext());
@@ -146,7 +149,7 @@ public class RecurringTransactionNotifications {
                         .setStyle(new NotificationCompat.BigTextStyle().bigText(schedTrx.inboxLine))
                         .setColor(mContext.getResources().getColor(R.color.md_primary));
 
-                if (!(schedTrx.mode.equals("A") && autoExecution)) {
+                if (!(schedTrx.mode.equals("A"))) {
                     builder
                             .addAction(R.drawable.ic_action_done_dark, getContext().getString(R.string.enter), enterPending)
                             .addAction(R.drawable.ic_action_content_clear_dark, getContext().getString(R.string.skip), skipPending);

--- a/app/src/main/java/com/money/manager/ex/notifications/RecurringTransactionReceiver.java
+++ b/app/src/main/java/com/money/manager/ex/notifications/RecurringTransactionReceiver.java
@@ -31,7 +31,7 @@ public class RecurringTransactionReceiver
 	public void onReceive(Context context, Intent intent) {
         // If the notifications are disabled in preferences, do not trigger the alarm.
         boolean notify = PreferenceManager.getDefaultSharedPreferences(context)
-                .getBoolean(context.getString(PreferenceConstants.PREF_REPEATING_TRANSACTION_NOTIFICATIONS), true);
+                .getBoolean(context.getString(PreferenceConstants.PREF_REPEATING_TRANSACTION_PROCESS), true);
         if (!notify) return;
 
         ScheduledTransactionWorker.enqueueWork(context);

--- a/app/src/main/java/com/money/manager/ex/notifications/ScheduledTransactionWorker.java
+++ b/app/src/main/java/com/money/manager/ex/notifications/ScheduledTransactionWorker.java
@@ -42,8 +42,8 @@ public class ScheduledTransactionWorker
 	@NonNull
 	@Override
 	public Result doWork() {
-		RecurringTransactionNotifications notifications = new RecurringTransactionNotifications(getApplicationContext());
-		notifications.notifyRepeatingTransaction();
+		RecurringTransactionProcess notifications = new RecurringTransactionProcess(getApplicationContext());
+		notifications.processRepeatingTransaction();
 		return Result.success();
 	}
 

--- a/app/src/main/java/com/money/manager/ex/settings/BehaviourSettings.java
+++ b/app/src/main/java/com/money/manager/ex/settings/BehaviourSettings.java
@@ -39,15 +39,8 @@ public class BehaviourSettings
         return PreferenceManager.getDefaultSharedPreferences(getContext());
     }
 
-    public boolean getNotificationRecurringTransaction() {
-        return get(PreferenceConstants.PREF_REPEATING_TRANSACTION_NOTIFICATIONS, true);
-    }
-
-    public boolean getExecutionScheduledTransaction() {
-        return get(R.string.pref_scheduled_transaction_execution, false);
-    }
-    public void setExecutionScheduledTransaction(boolean status) {
-        set(R.string.pref_scheduled_transaction_execution, status);
+    public boolean getProcessRecurringTransaction() {
+        return get(PreferenceConstants.PREF_REPEATING_TRANSACTION_PROCESS, true);
     }
 
     public boolean getUseNestedCategory() {

--- a/app/src/main/java/com/money/manager/ex/settings/BehaviourSettings.java
+++ b/app/src/main/java/com/money/manager/ex/settings/BehaviourSettings.java
@@ -46,6 +46,9 @@ public class BehaviourSettings
     public boolean getExecutionScheduledTransaction() {
         return get(R.string.pref_scheduled_transaction_execution, false);
     }
+    public void setExecutionScheduledTransaction(boolean status) {
+        set(R.string.pref_scheduled_transaction_execution, status);
+    }
 
     public boolean getUseNestedCategory() {
         return get(R.string.pref_use_nested_category, false);

--- a/app/src/main/java/com/money/manager/ex/settings/BehaviourSettingsFragment.java
+++ b/app/src/main/java/com/money/manager/ex/settings/BehaviourSettingsFragment.java
@@ -75,15 +75,6 @@ public class BehaviourSettingsFragment
                 return true;
             });
 
-//            // set initial value
-//            boolean autoExecTransaction = settings.getExecutionScheduledTransaction();
-//            autoExecTransactionSwitch.setChecked(autoExecTransaction);
-
-//            autoExecTransactionSwitch.setOnPreferenceChangeListener((preference, newValue) -> {
-//                settings.setExecutionScheduledTransaction((Boolean) newValue);
-//                MainActivity.setRestartActivity(true);
-//                return true;
-//            });
         }
 
     }

--- a/app/src/main/java/com/money/manager/ex/settings/BehaviourSettingsFragment.java
+++ b/app/src/main/java/com/money/manager/ex/settings/BehaviourSettingsFragment.java
@@ -28,6 +28,8 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
+import androidx.preference.PreferenceManager;
+import androidx.preference.SwitchPreference;
 
 import com.money.manager.ex.Constants;
 import com.money.manager.ex.R;
@@ -56,6 +58,34 @@ public class BehaviourSettingsFragment
 
         initializeNotificationTime();
         initializeSmsAutomation();
+
+        PreferenceManager.getDefaultSharedPreferences(getActivity());
+        final BehaviourSettings settings = new AppSettings(getActivity()).getBehaviourSettings();
+        final SwitchPreference showNotificationSwitch = findPreference(getString(R.string.pref_repeating_transaction_notifications));
+        final SwitchPreference autoExecTransactionSwitch = findPreference(getString(R.string.pref_scheduled_transaction_execution));
+        if (showNotificationSwitch != null && autoExecTransactionSwitch != null) {
+            autoExecTransactionSwitch.setEnabled(showNotificationSwitch.isChecked());
+
+            showNotificationSwitch.setOnPreferenceChangeListener((preference, newValue) -> {
+                autoExecTransactionSwitch.setEnabled((Boolean) newValue);
+                if (!autoExecTransactionSwitch.isEnabled()) {
+                    autoExecTransactionSwitch.setChecked(false);
+                    settings.setExecutionScheduledTransaction(false);
+                }
+                return true;
+            });
+
+//            // set initial value
+//            boolean autoExecTransaction = settings.getExecutionScheduledTransaction();
+//            autoExecTransactionSwitch.setChecked(autoExecTransaction);
+
+//            autoExecTransactionSwitch.setOnPreferenceChangeListener((preference, newValue) -> {
+//                settings.setExecutionScheduledTransaction((Boolean) newValue);
+//                MainActivity.setRestartActivity(true);
+//                return true;
+//            });
+        }
+
     }
 
     @Override

--- a/app/src/main/java/com/money/manager/ex/settings/BehaviourSettingsFragment.java
+++ b/app/src/main/java/com/money/manager/ex/settings/BehaviourSettingsFragment.java
@@ -58,24 +58,6 @@ public class BehaviourSettingsFragment
         initializeNotificationTime();
         initializeSmsAutomation();
 
-        PreferenceManager.getDefaultSharedPreferences(getActivity());
-        final BehaviourSettings settings = new AppSettings(getActivity()).getBehaviourSettings();
-        final SwitchPreference showNotificationSwitch = findPreference(getString(R.string.pref_repeating_transaction_notifications));
-        final SwitchPreference autoExecTransactionSwitch = findPreference(getString(R.string.pref_scheduled_transaction_execution));
-        if (showNotificationSwitch != null && autoExecTransactionSwitch != null) {
-            autoExecTransactionSwitch.setEnabled(showNotificationSwitch.isChecked());
-
-            showNotificationSwitch.setOnPreferenceChangeListener((preference, newValue) -> {
-                autoExecTransactionSwitch.setEnabled((Boolean) newValue);
-                if (!autoExecTransactionSwitch.isEnabled()) {
-                    autoExecTransactionSwitch.setChecked(false);
-                    settings.setExecutionScheduledTransaction(false);
-                }
-                return true;
-            });
-
-        }
-
     }
 
     @Override

--- a/app/src/main/java/com/money/manager/ex/settings/PreferenceConstants.java
+++ b/app/src/main/java/com/money/manager/ex/settings/PreferenceConstants.java
@@ -53,7 +53,7 @@ public class PreferenceConstants {
     // others preference setting don't display
 
     // check scheduled transaction
-    public static final Integer PREF_REPEATING_TRANSACTION_PROCESS = R.string.pref_repeating_transaction_process;
+    public static final Integer PREF_REPEATING_TRANSACTION_PROCESS = R.string.pref_repeating_transaction_notifications;
     public static final Integer PREF_REPEATING_TRANSACTION_CHECK = R.string.pref_repeating_transaction_check_time;
 
     public static final Integer PREF_DASHBOARD_GROUP_VISIBLE = R.string.pref_dashboard_group_visibility;

--- a/app/src/main/java/com/money/manager/ex/settings/PreferenceConstants.java
+++ b/app/src/main/java/com/money/manager/ex/settings/PreferenceConstants.java
@@ -53,7 +53,7 @@ public class PreferenceConstants {
     // others preference setting don't display
 
     // check scheduled transaction
-    public static final Integer PREF_REPEATING_TRANSACTION_NOTIFICATIONS = R.string.pref_repeating_transaction_notifications;
+    public static final Integer PREF_REPEATING_TRANSACTION_PROCESS = R.string.pref_repeating_transaction_process;
     public static final Integer PREF_REPEATING_TRANSACTION_CHECK = R.string.pref_repeating_transaction_check_time;
 
     public static final Integer PREF_DASHBOARD_GROUP_VISIBLE = R.string.pref_dashboard_group_visibility;

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -408,8 +408,6 @@
   <string name="donate_in_app_already_donate">Du har allerede støttet udviklingen af MoneyManagerEx til Android med din donation!\n\nTak fra udviklingsteamet!</string>
   <string name="donate_in_app_retrieving_status">Henter donationsstatus fra Google Play. Vent venligst&#8230;</string>
   <string name="donate_in_app_error">Kan ikke bruge in-app fakturering. Tjek, om den seneste version af Play Butik-appen er installeret.</string>
-  <string name="title_notifications_repeating_transaction">Forfalden planlagt transaktion-notifikation </string>
-  <string name="summary_notifications_repeating_transaction">Vis notifikation om forfalden planlagt transaktion</string>
   <string name="tools">Værktøjer</string>
   <string name="entities">Enheder</string>
   <string name="loading">Indlæser&#8230;</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -408,8 +408,6 @@
   <string name="donate_in_app_already_donate">Sie haben schon die Entwicklung vonYou already MoneyManagerEx für Android mit einer Spende unterstützt!\n\nDanke das Entwicklerteam!</string>
   <string name="donate_in_app_retrieving_status">Rufe den Status Ihrer Spende von Google Play ab. Bitte warten&#8230;</string>
   <string name="donate_in_app_error">Der in-app Kauf kann nicht verwendet werden. Überprüfen Sie ob die neuste Version von Play Store installiert ist.</string>
-  <string name="title_notifications_repeating_transaction">Benachrichtigung: geplante Buchung überfällig </string>
-  <string name="summary_notifications_repeating_transaction">Benachrichtigung für überfällige geplante Buchungen anzeigen</string>
   <string name="tools">Werkzeuge</string>
   <string name="entities">Extras</string>
   <string name="loading">Wird geladen&#8230;</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -391,8 +391,8 @@
   <string name="donate_in_app_already_donate">Hai già sostenuto lo sviluppo di MoneyManagerEx per Android con una donazione! \n\nGrazie mille dal team di sviluppo!</string>
   <string name="donate_in_app_retrieving_status">Recupero dello stato delle vostre donazioni da Google Play. Attendere prego&#8230;</string>
   <string name="donate_in_app_error">Non è possibile utilizzare il pagamento in-app. Verifica se è installata l\'ultima versione dell\'applicazione Play Store.</string>
-  <string name="title_notifications_repeating_transaction">Notifica Transazione Pianificata scaduta </string>
-  <string name="summary_notifications_repeating_transaction">Mostra notifica per le transazioni pianificate scadute</string>
+  <string name="title_repeating_transaction_process">"Processa Transazione Pianificata scaduta "</string>
+  <string name="summary_repeating_transaction_process">Processa le transazioni scadute (Inserimento, Notifica, Manuale)</string>
   <string name="tools">Strumenti</string>
   <string name="entities">Entità</string>
   <string name="loading">Caricamento in corso&#8230;</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -404,7 +404,7 @@
   <string name="donate_in_app_already_donate">Za razvoj razvojne MoneyManagerEx za Android ste že podpirali z donacijo!\n\n In zahvaljuje se vam razvojna ekipa!</string>
   <string name="donate_in_app_retrieving_status">Pridobivanje statusa vaših prispevkov v Googlu Play. Prosim počakajte&#8230;</string>
   <string name="donate_in_app_error">Zaračunavanja v aplikaciji ni mogoče uporabiti. Preverite, ali je nameščena najnovejša različica aplikacije Trgovina Play.</string>
-  <string name="title_notifications_repeating_transaction"></string>
+  <string name="title_repeating_transaction_process"></string>
   <string name="tools">Orodja</string>
   <string name="entities">Subjekti</string>
   <string name="loading">Nalaganje&#8230;</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -408,8 +408,6 @@
   <string name="donate_in_app_already_donate">Ви вже підтримали розробників MoneyManagerEx для Android пожертвою! \n\nПодяка вам від команди розробників!</string>
   <string name="donate_in_app_retrieving_status">Отримання статусу ваших пожертв із Google Play. Прошу чекати&#8230;</string>
   <string name="donate_in_app_error">Не можна використовувати оплату в програмі. Перевірте, чи інстальовано останню версію Play Store.</string>
-  <string name="title_notifications_repeating_transaction">Сповіщення про протерміновану заплановану операцію</string>
-  <string name="summary_notifications_repeating_transaction">Показати сповіщення про протерміновану заплановану операцію</string>
   <string name="tools">Інструменти</string>
   <string name="entities">Сутності</string>
   <string name="loading">Завантаження&#8230;</string>

--- a/app/src/main/res/values/prefids.xml
+++ b/app/src/main/res/values/prefids.xml
@@ -80,7 +80,7 @@
     <string name="pref_behaviour">prefbehaviour</string>
     <string name="pref_behaviour_focus_filter">prefbehaviour_focus_filter</string>
     <string name="pref_show_introduction">prefshowintroduction</string>
-    <string name="pref_repeating_transaction_process">prefrepeatingtransactionprocess</string>
+    <string name="pref_repeating_transaction_notifications">prefrepeatingtransactionprocess</string>
     <string name="pref_income_expense_footer_period">pref_income_expense_footer_period</string>
     <string name="pref_asset_allocation_threshold">pref_asset_allocation_threshold</string>
     <string name="pref_repeating_transaction_check_time">prefrepeatingtransactionchecktime</string>

--- a/app/src/main/res/values/prefids.xml
+++ b/app/src/main/res/values/prefids.xml
@@ -80,8 +80,7 @@
     <string name="pref_behaviour">prefbehaviour</string>
     <string name="pref_behaviour_focus_filter">prefbehaviour_focus_filter</string>
     <string name="pref_show_introduction">prefshowintroduction</string>
-    <string name="pref_repeating_transaction_notifications">prefrepeatingtransactionnotifications</string>
-    <string name="pref_scheduled_transaction_execution">prefscheduledtransactionexecution</string>
+    <string name="pref_repeating_transaction_process">prefrepeatingtransactionprocess</string>
     <string name="pref_income_expense_footer_period">pref_income_expense_footer_period</string>
     <string name="pref_asset_allocation_threshold">pref_asset_allocation_threshold</string>
     <string name="pref_repeating_transaction_check_time">prefrepeatingtransactionchecktime</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -436,10 +436,8 @@
     <string name="donate_in_app_already_donate">You already supported the development of MoneyManagerEx for Android with your donation!\n\nThank you from development team!</string>
     <string name="donate_in_app_retrieving_status">Retrieving status of your donations from Google Play. Please wait…</string>
     <string name="donate_in_app_error">Cannot use the in-app billing. Check whether the latest version of the Play Store application is installed.</string>
-    <string name="title_notifications_repeating_transaction">Notification Scheduled Transaction overdue </string>
-    <string name="title_execution_scheduled_transaction">Execution Scheduled Transaction overdue </string>
-    <string name="summary_notifications_repeating_transaction">Show notification for scheduled transaction overdue</string>
-    <string name="summary_execution_scheduled_transaction">Auto execution for scheduled transaction overdue</string>
+    <string name="title_repeating_transaction_process">Process Scheduled Transaction</string>
+    <string name="summary_repeating_transaction_process">Process scheduled transaction overdue (Post, Prompt, Manual)</string>
 
     <string name="title_use_nested_category">(BETA) Use new nested category model</string>
     <string name="summary_use_nested_category">Use new nested category model instead of category:subcategory model (Beta, use at own risk)</string>

--- a/app/src/main/res/xml/preferences_behaviour.xml
+++ b/app/src/main/res/xml/preferences_behaviour.xml
@@ -27,21 +27,14 @@
     <SwitchPreference
         android:icon="@null"
         android:defaultValue="true"
-        android:key="@string/pref_repeating_transaction_notifications"
-        android:summary="@string/summary_notifications_repeating_transaction"
-        android:title="@string/title_notifications_repeating_transaction" />
-
-    <SwitchPreference
-        android:icon="@null"
-        android:defaultValue="false"
-        android:key="@string/pref_scheduled_transaction_execution"
-        android:summary="@string/summary_execution_scheduled_transaction"
-        android:title="@string/title_execution_scheduled_transaction" />
+        android:key="@string/pref_repeating_transaction_process"
+        android:summary="@string/summary_repeating_transaction_process"
+        android:title="@string/title_repeating_transaction_process" />
 
     <Preference
         android:icon="@null"
         android:defaultValue="08:00"
-        android:dependency="@string/pref_repeating_transaction_notifications"
+        android:dependency="@string/pref_repeating_transaction_process"
         android:key="@string/pref_repeating_transaction_check_time"
         android:summary="@string/summary_check_repeating_transaction"
         android:title="@string/title_check_repeating_transaction" />

--- a/app/src/main/res/xml/preferences_behaviour.xml
+++ b/app/src/main/res/xml/preferences_behaviour.xml
@@ -27,14 +27,14 @@
     <SwitchPreference
         android:icon="@null"
         android:defaultValue="true"
-        android:key="@string/pref_repeating_transaction_process"
+        android:key="@string/pref_repeating_transaction_notifications"
         android:summary="@string/summary_repeating_transaction_process"
         android:title="@string/title_repeating_transaction_process" />
 
     <Preference
         android:icon="@null"
         android:defaultValue="08:00"
-        android:dependency="@string/pref_repeating_transaction_process"
+        android:dependency="@string/pref_repeating_transaction_notifications"
         android:key="@string/pref_repeating_transaction_check_time"
         android:summary="@string/summary_check_repeating_transaction"
         android:title="@string/title_check_repeating_transaction" />

--- a/docs/usermanual/index.md
+++ b/docs/usermanual/index.md
@@ -61,7 +61,10 @@ Protect your financial information with advanced security features, including pa
 
 Support for recurring and schedule transactions. Recurring can be Manual, Prompt (with notifications) or Automatic (controlled by setting switch).
 > [!IMPORTANT]
-> Autopost require to be activate in setting --> beavhiour --> Execution Schedule Transaction Overdue
+> Expired Recurring Transaction require to have correct Type set into transaction
+> AUTO: Means that transaction is auto posted when expired
+> PROMPT: Means that transaction is show in a notification with action skip/enter for user decision
+> MANUAL: Means that no action is taken on recurring transaction (no auto post, no notification)
 
 
 ### Nested Category


### PR DESCRIPTION
Single Switch as "Process Schedule Transaction" that:
- Autopost "Auto" expired Transaction
- Prompt "Prompt" exipred Transaction
- Nothing for "Manual" exipred Transaction
Documentation also updated

Close #1812
Clarification on #1683
Close #1798

refer also to old implementation on PR #1814 