### PR TITLE
change log for v1039 release

### DIFF
--- a/metadata/android/en-US/changelogs/1039.txt
+++ b/metadata/android/en-US/changelogs/1039.txt
@@ -1,0 +1,15 @@
+Features:
+- Add financial year support in reports and transaction lists.
+- Unify Deposit/Withdrawal AS transfer, not counted in Income vs Expenses.
+- Refine Notification & Autopost switch logic.
+
+Refactors:
+- Moved DBPref into SharedPreference for unified preference management.
+- Upgrade JDK17
+
+Bug Fixes:
+- Minor cleanups across various files and logic.
+- Updated minSdkVersion to 23.
+
+Doc Updates:
+- Updated documentation for nested categories, recurring transactions, and JDK17 reference.


### PR DESCRIPTION
the size is fine (maximum size: 500 characters)
```
$ wc -c metadata/android/en-US/changelogs/1039.txt
     493 metadata/android/en-US/changelogs/1039.txt
```


https://f-droid.org/docs/All_About_Descriptions_Graphics_and_Screenshots/