### PR TITLE
handle error on date user format

### DIFF
--- a/app/src/main/java/com/money/manager/ex/transactions/EditTransactionCommonFunctions.java
+++ b/app/src/main/java/com/money/manager/ex/transactions/EditTransactionCommonFunctions.java
@@ -1502,8 +1502,13 @@ public class EditTransactionCommonFunctions {
     private void showDate(Date dateTime) {
         // Constants.LONG_DATE_MEDIUM_DAY_PATTERN
         String format = "EEE, " + getUserDateFormat();
-        //String display = dateTime.toString(format);
-        String display = dateTimeUtilsLazy.get().format(dateTime, format);
+        String display;
+        try {
+            display = dateTimeUtilsLazy.get().format(dateTime, format);
+        } catch (Exception e) {
+            Timber.e(e, "Error formatting date with ["+format+"]");
+            display = dateTimeUtilsLazy.get().format(dateTime, Constants.LONG_DATE_MEDIUM_DAY_PATTERN);
+        }
         viewHolder.dateTextView.setText(display);
     }
 

--- a/app/src/main/java/com/money/manager/ex/transactions/EditTransactionCommonFunctions.java
+++ b/app/src/main/java/com/money/manager/ex/transactions/EditTransactionCommonFunctions.java
@@ -1502,13 +1502,7 @@ public class EditTransactionCommonFunctions {
     private void showDate(Date dateTime) {
         // Constants.LONG_DATE_MEDIUM_DAY_PATTERN
         String format = "EEE, " + getUserDateFormat();
-        String display;
-        try {
-            display = dateTimeUtilsLazy.get().format(dateTime, format);
-        } catch (Exception e) {
-            Timber.e(e, "Error formatting date with ["+format+"]");
-            display = dateTimeUtilsLazy.get().format(dateTime, Constants.LONG_DATE_MEDIUM_DAY_PATTERN);
-        }
+        String display = dateTimeUtilsLazy.get().format(dateTime, format);
         viewHolder.dateTextView.setText(display);
     }
 

--- a/app/src/main/java/com/money/manager/ex/utils/MmxDateTimeUtils.java
+++ b/app/src/main/java/com/money/manager/ex/utils/MmxDateTimeUtils.java
@@ -21,6 +21,7 @@ import android.content.Context;
 import android.text.TextUtils;
 import android.widget.DatePicker;
 
+import com.money.manager.ex.Constants;
 import com.money.manager.ex.MmexApplication;
 import com.money.manager.ex.R;
 import com.money.manager.ex.core.DateRange;
@@ -33,6 +34,8 @@ import java.util.Date;
 import java.util.Locale;
 
 import javax.inject.Inject;
+
+import timber.log.Timber;
 
 /**
  * Date/time utilities using Java standard Date classes.
@@ -219,6 +222,11 @@ public class MmxDateTimeUtils {
      */
 
     private SimpleDateFormat getFormatterFor(String format) {
-        return new SimpleDateFormat(format, _locale);
+        try {
+            return new SimpleDateFormat(format, _locale);
+        } catch (Exception e) {
+            Timber.e(e, "Error formatting date with ["+format+"]");
+            return new SimpleDateFormat(Constants.LONG_DATE_MEDIUM_DAY_PATTERN, _locale);
+        }
     }
 }


### PR DESCRIPTION
See dump on gPlay
```
Caused by java.lang.IllegalArgumentException:
  at java.text.SimpleDateFormat.compile (SimpleDateFormat.java:953)
  at java.text.SimpleDateFormat.initialize (SimpleDateFormat.java:739)
  at java.text.SimpleDateFormat.<init> (SimpleDateFormat.java:710)
  at com.money.manager.ex.utils.MmxDateTimeUtils.getFormatterFor (MmxDateTimeUtils.java:222)
  at com.money.manager.ex.utils.MmxDateTimeUtils.format (MmxDateTimeUtils.java:68)
  at com.money.manager.ex.transactions.EditTransactionCommonFunctions.showDate (EditTransactionCommonFunctions.java:1506)
  at com.money.manager.ex.transactions.EditTransactionCommonFunctions.initDateSelector (EditTransactionCommonFunctions.java:483)
  at com.money.manager.ex.transactions.CheckingTransactionEditActivity.initializeInputControls (CheckingTransactionEditActivity.java:357)
  at com.money.manager.ex.transactions.CheckingTransactionEditActivity.onCreate (CheckingTransactionEditActivity.java:121)
  at android.app.Activity.performCreate (Activity.java:8616)
  at android.app.Activity.performCreate (Activity.java:8594)
  at android.app.Instrumentation.callActivityOnCreate (Instrumentation.java:1460)
  at android.app.ActivityThread.performLaunchActivity (ActivityThread.java:3918)
```