### PR TITLE
Sync: forceMetadataRefresh

### DIFF
--- a/app/src/main/java/com/money/manager/ex/core/docstorage/DocFileMetadata.java
+++ b/app/src/main/java/com/money/manager/ex/core/docstorage/DocFileMetadata.java
@@ -35,6 +35,13 @@ public class DocFileMetadata {
         result.Uri = uri.toString();
         result.lastModified = new MmxDate(0); // Default value
 
+        try {
+            context.getContentResolver().notifyChange(uri, null);
+            Timber.d("Metadata refresh triggered for URI: %s", uri);
+        } catch (Exception e) {
+            Timber.w(e, "Failed to refresh metadata for URI: %s", uri);
+        }
+
         // Try with DocumentFile first
         try {
             DocumentFile documentFile = DocumentFile.fromSingleUri(context, uri);

--- a/app/src/main/java/com/money/manager/ex/core/docstorage/FileStorageHelper.java
+++ b/app/src/main/java/com/money/manager/ex/core/docstorage/FileStorageHelper.java
@@ -280,7 +280,7 @@ public class FileStorageHelper {
                 DocFileMetadata remote = DocFileMetadata.fromUri(_host, uri);
                 Date storedLastChange = MmxDate.fromIso8601(metadata.remoteLastChangedDate).toDate();
 
-                if (remote.lastModified.toDate().before(storedLastChange)) {
+                if (remote.lastModified.toDate().equals(storedLastChange)) {
                     // repeat
                     Timber.d("fetching the actual remote metadata...");
                     handler.postDelayed(this, milliseconds); // Optional, to repeat the task.

--- a/app/src/main/java/com/money/manager/ex/core/docstorage/FileStorageHelper.java
+++ b/app/src/main/java/com/money/manager/ex/core/docstorage/FileStorageHelper.java
@@ -280,7 +280,7 @@ public class FileStorageHelper {
                 DocFileMetadata remote = DocFileMetadata.fromUri(_host, uri);
                 Date storedLastChange = MmxDate.fromIso8601(metadata.remoteLastChangedDate).toDate();
 
-                if (remote.lastModified.toDate().equals(storedLastChange)) {
+                if (remote.lastModified.toDate().before(storedLastChange)) {
                     // repeat
                     Timber.d("fetching the actual remote metadata...");
                     handler.postDelayed(this, milliseconds); // Optional, to repeat the task.


### PR DESCRIPTION
align with the existing logic to trigger `pollNewRemoteTimestamp`

```
        if (remote.lastModified.toDate().before(localLastModified)) {
            // The metadata has not been updated yet!
            // Solve this problem by polling until new value fetched. (doh!)
            pollNewRemoteTimestamp(metadata);
        } else {
            metadata.remoteLastChangedDate = remote.lastModified.toIsoString();
        }
```