### PR TITLE
Support creating automatic transaction from SMS for database v19

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,10 @@
     <!--<uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />-->
     <!--<uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />-->
 
+    <!-- SMS Interface -->
+    <uses-permission android:name="android.permission.RECEIVE_SMS" />
+    <uses-permission android:name="android.permission.READ_SMS" />
+
     <!-- Fingerprint Interface -->
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
 

--- a/app/src/main/java/com/money/manager/ex/notifications/SmsReceiverTransactions.java
+++ b/app/src/main/java/com/money/manager/ex/notifications/SmsReceiverTransactions.java
@@ -382,7 +382,7 @@ public class SmsReceiverTransactions extends BroadcastReceiver {
                                 t_intent.putExtra(EditTransactionActivityConstants.KEY_TRANS_AMOUNT, String.valueOf(mCommon.transactionEntity.getAmount()));
                                 t_intent.putExtra(EditTransactionActivityConstants.KEY_NOTES, mCommon.transactionEntity.getNotes());
                                 t_intent.putExtra(EditTransactionActivityConstants.KEY_TRANS_DATE, mCommon.transactionEntity.getDate());
- //                               t_intent.putExtra(EditTransactionActivityConstants.KEY_TRANS_NUMBER, mCommon.transactionEntity.getTransactionNumber());
+                                t_intent.putExtra(EditTransactionActivityConstants.KEY_TRANS_NUMBER, mCommon.transactionEntity.getTransactionNumber());
 
                                 // validate and save the transaction
                                 if(!skipSaveTrans) {

--- a/app/src/main/java/com/money/manager/ex/notifications/SmsReceiverTransactions.java
+++ b/app/src/main/java/com/money/manager/ex/notifications/SmsReceiverTransactions.java
@@ -135,7 +135,7 @@ public class SmsReceiverTransactions extends BroadcastReceiver {
                         msgBody += msgs[i].getMessageBody();
                     }
 
-                    msgSender = "AT-SIBSMS";
+                    //msgSender = "AT-SIBSMS";
 
                     if(isTransactionSms(msgSender)) {
                         // Transaction Sms sender will have format like this AT-SIBSMS,
@@ -386,6 +386,9 @@ public class SmsReceiverTransactions extends BroadcastReceiver {
 
                                 // validate and save the transaction
                                 if(!skipSaveTrans) {
+
+                                    t_intent.addFlags((Intent.FLAG_ACTIVITY_NEW_TASK)); // Fix for https://github.com/moneymanagerex/android-money-manager-ex/issues/2210
+
                                     if (validateData()) {
                                         if (saveTransaction()) {
 

--- a/app/src/main/java/com/money/manager/ex/notifications/SmsReceiverTransactions.java
+++ b/app/src/main/java/com/money/manager/ex/notifications/SmsReceiverTransactions.java
@@ -898,10 +898,9 @@ public class SmsReceiverTransactions extends BroadcastReceiver {
                 String sql =
                         "SELECT CATEGID, CATEGNAME, PARENTID FROM CATEGORY_V1  " +
                                 "WHERE CATEGNAME = '" + searchName + "' " +
-                                "AND PARENTID >0 " +
-                                "ORDER BY CATEGNAME  LIMIT 1";
+                                "ORDER BY PARENTID desc, CATEGNAME asc  LIMIT 1";
 
-                Log.d("SQL", sql);
+                //Log.d("SQL", sql);
                 Cursor cCursor = db.query(sql);
 
                 if(cCursor.moveToFirst())
@@ -910,24 +909,6 @@ public class SmsReceiverTransactions extends BroadcastReceiver {
                             cCursor.getString(cCursor.getColumnIndex("CATEGID")),
                             cCursor.getString(cCursor.getColumnIndex("PARENTID"))
                     };
-                } else{ //search in only catogery
-
-                    sql =
-                            "SELECT c.CATEGID, c.CATEGNAME, PARENTID " +
-                                    "FROM CATEGORY_V1 c  " +
-                                    "WHERE c.CATEGNAME = '" + searchName + "' " +
-                                    "AND AND PARENTID =-1 " +
-                                    "ORDER BY c.CATEGID  LIMIT 1";
-
-                    cCursor = db.query(sql);
-
-                    if(cCursor.moveToFirst())
-                    {
-                        cTran = new String[]{
-                                cCursor.getString(cCursor.getColumnIndex("CATEGID")),
-                                "-1"
-                        };
-                    }
                 }
 
                 cCursor.close();

--- a/app/src/main/java/com/money/manager/ex/notifications/SmsReceiverTransactions.java
+++ b/app/src/main/java/com/money/manager/ex/notifications/SmsReceiverTransactions.java
@@ -135,7 +135,7 @@ public class SmsReceiverTransactions extends BroadcastReceiver {
                         msgBody += msgs[i].getMessageBody();
                     }
 
-                    //msgSender = "AT-SIBSMS";
+                    msgSender = "AT-SIBSMS";
 
                     if(isTransactionSms(msgSender)) {
                         // Transaction Sms sender will have format like this AT-SIBSMS,
@@ -252,7 +252,7 @@ public class SmsReceiverTransactions extends BroadcastReceiver {
 
                                 //get the ref no. if doesn't exits
                                 if(transRefNo.isEmpty()){
-                                    transRefNo = new SimpleDateFormat("yyyyMMddHHmmss").format(new java.util.Date());
+                                    transRefNo = new SimpleDateFormat("yyyyMMddHHmmss").format(new Date());
                                 }
 
                                 //set the txn no
@@ -784,13 +784,13 @@ public class SmsReceiverTransactions extends BroadcastReceiver {
                 "(I[D//d](.)?(:)?(\\s)?((.*?)\\w+))", "(I[D//d](.)?(:)?)(\\s)?(\\d+)", "(id(\\s)is(\\s)?(:)?(\\d+))",
                 "((Reference:)(\\s)?(\\d+))",  "([\\*](\\d+)[\\*])", "(Info(:)+(.*?)(\\d+)[:]?[-]?)",
                 "((reference number)(.*?)(\\d+))", "(\\s)?#(\\s?)(\\d+)(\\s?)",  "(\\/+(\\d+)+\\/)",
-                "((?:UPI|IMPS)\\s?:\\s?(\\d+)\\s?)", "(InfoPKT(.*?)(\\d+)\\s?)"};
+                "((?:UPI|IMPS)\\s?:\\s?(\\d+)\\s?)", "([\\*](.*?)(\\d+)\\s?)", "(I[Dd]\\s?([.:])\\s?((.*?)(\\d+))\\s)"};
 
         int[] getGroup = {2, 3, 2,
                           5, 5, 5,
                           4, 2, 4,
                           4, 3, 2,
-                          2, 3};
+                          2, 3, 3};
 
         try
         {
@@ -982,9 +982,7 @@ public class SmsReceiverTransactions extends BroadcastReceiver {
     public boolean validateData() {
 
         boolean isTransfer = mCommon.transactionEntity.getTransactionType().equals(TransactionTypes.Transfer);
-        Core core = new Core(mContext);
 
-        Log.d("Vels Tag Equals : ", String.valueOf(mCommon.transactionEntity.getAccountId().equals(Constants.NOT_SET)));
         if (mCommon.transactionEntity.getAccountId().equals(Constants.NOT_SET)) {
             //Toast.makeText(mContext, "MMEX : " + (R.string.error_toaccount_not_selected), Toast.LENGTH_LONG).show();
             return false;
@@ -1022,9 +1020,12 @@ public class SmsReceiverTransactions extends BroadcastReceiver {
         }
 
         // Category is required if tx is not a split or transfer.
-        boolean hasCategory = mCommon.transactionEntity.hasCategory();
-        //Toast.makeText(mContext, "MMEX : " + (R.string.error_category_not_selected), Toast.LENGTH_LONG).show();
-        return hasCategory || isTransfer;
+        if (!mCommon.transactionEntity.hasCategory()) {
+            //Toast.makeText(mContext, "MMEX : " + (R.string.error_category_not_selected), Toast.LENGTH_LONG).show();
+            return false;
+        }
+
+        return isTransfer;
     }
 
     public boolean saveTransaction() {


### PR DESCRIPTION
Updated with additional RegEx to support more transactional sms. Changes are made in the following methods,

- extractTransRefNo
- extractTransPayee
- extractTransRefNo

Also migrated query to support db version 19.

Release Notes: 

1. Handled additional transactional SMS to support creating automatic transaction
2. Now SMS Transaction processing is supported for db version 19