### PR TITLE
Database Version: auto downgrade from v20 to v19 with no schema change

### DIFF
--- a/app/src/main/java/com/money/manager/ex/database/MmxOpenHelper.java
+++ b/app/src/main/java/com/money/manager/ex/database/MmxOpenHelper.java
@@ -128,6 +128,13 @@ public class MmxOpenHelper extends SupportSQLiteOpenHelper.Callback {
         updateDatabase(db, oldVersion, newVersion);
     }
 
+    public void onDowngrade (SupportSQLiteDatabase db, int oldVersion, int newVersion) {
+        Timber.d("Downgrading from version %d to %d", oldVersion, newVersion);
+        if (oldVersion == 20 && newVersion == DATABASE_VERSION) return;
+
+        super.onDowngrade(db, oldVersion, newVersion);
+    }
+
     private SupportSQLiteDatabase getDatabase(boolean writable) {
         SupportSQLiteOpenHelper.Factory factory = new SupportFactory(this.mPassword.getBytes());
         SupportSQLiteOpenHelper.Configuration configuration =

--- a/app/src/main/java/com/money/manager/ex/database/MmxOpenHelper.java
+++ b/app/src/main/java/com/money/manager/ex/database/MmxOpenHelper.java
@@ -54,7 +54,8 @@ public class MmxOpenHelper extends SupportSQLiteOpenHelper.Callback {
      * Database schema version.
      */
     private static final int DATABASE_VERSION = 19;
-    private String dbPath;
+    private static final int DATABASE_VERSION_20 = 20;
+    private final String dbPath;
 
     // Dynamic
 
@@ -130,7 +131,7 @@ public class MmxOpenHelper extends SupportSQLiteOpenHelper.Callback {
 
     public void onDowngrade (SupportSQLiteDatabase db, int oldVersion, int newVersion) {
         Timber.d("Downgrading from version %d to %d", oldVersion, newVersion);
-        if (oldVersion == 20 && newVersion == DATABASE_VERSION) return;
+        if (oldVersion == DATABASE_VERSION_20 && newVersion == DATABASE_VERSION) return;
 
         super.onDowngrade(db, oldVersion, newVersion);
     }


### PR DESCRIPTION
to impl
- #2219

as there is no schema change from v19 to v20, this is to keep a good compatibility 
it will perform a downgrade from v20 to v19, and expect the new app (either desktop or android) to upgrade from v19 to v20 again.


and in the future release, will update DATABASE_VERSION to 20 and tune the code again