### PR TITLE
Try to handle correct load of fragment

### DIFF
--- a/app/src/main/java/com/money/manager/ex/nestedcategory/NestedCategoryListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/nestedcategory/NestedCategoryListFragment.java
@@ -594,4 +594,13 @@ public class NestedCategoryListFragment
         startActivity(intent);
     }
 
+    @Override
+    public void onResume(){
+        super.onResume();
+        // force reset loader on start. try to fix 2217, not the best code
+        // becouse normaly was call duble
+        restartLoader();
+    }
+
+
 }

--- a/app/src/main/java/com/money/manager/ex/payee/PayeeListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/payee/PayeeListFragment.java
@@ -94,6 +94,11 @@ public class PayeeListFragment
         super.onActivityCreated(savedInstanceState);
 
         mContext = getActivity();
+        // mAction is not aways set since PayeeActivity is not call from main #2217
+        mAction = getActivity().getIntent().getAction();
+        if (!mAction.equals(Intent.ACTION_PICK)) {
+            mAction = Intent.ACTION_EDIT;
+        }
 
         setSearchMenuVisible(true);
         // Focus on search menu if set in preferences.
@@ -154,10 +159,19 @@ public class PayeeListFragment
         // set floating button visible
         setFloatingActionButtonVisible(true);
         attachFloatingActionButtonToListView();
+
     }
 
-    // Menu
+    @Override
+    public void onResume(){
+        super.onResume();
+        // force reset loader on start. try to fix 2217, not the best code
+        // becouse normaly was call duble
+        restartLoader();
+    }
 
+
+    // Menu
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
         super.onCreateOptionsMenu(menu, inflater);


### PR DESCRIPTION
close #2217

@guanlisheng did you have any suggestion to prevent wrong behavior describe in comment https://github.com/moneymanagerex/android-money-manager-ex/issues/2217#issuecomment-2641782515

anyway this code work, even if normaly loader is called twice (excep when reenter in payee fragment after new payee from traneaction)