### PR TITLE
Added a trim before checking for space to be replaced by _ in Tag Name

### DIFF
--- a/app/src/main/java/com/money/manager/ex/tag/TagListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/tag/TagListFragment.java
@@ -388,7 +388,7 @@ public class TagListFragment     extends BaseListFragment
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
                         // take tag name from the input field.
-                        String name = edtTagName.getText().toString();
+                        String name = edtTagName.getText().toString().trim();
 
                         // issue #2030: PC version does not support space
                         if (name.contains(" ") || name.contains("&") || name.contains("|")) {


### PR DESCRIPTION
Added a trim before checking for space to be replaced by _, so that we can avoid underscore prefixed or suffixed in tag name