### PR TITLE
SMS: minor correction in method isTransactionSms

### DIFF
--- a/app/src/main/java/com/money/manager/ex/notifications/SmsReceiverTransactions.java
+++ b/app/src/main/java/com/money/manager/ex/notifications/SmsReceiverTransactions.java
@@ -493,7 +493,7 @@ public class SmsReceiverTransactions extends BroadcastReceiver {
 
         try
         {
-            Pattern p = Pattern.compile("(-?[a-zA-Z]+)");
+            Pattern p = Pattern.compile("(-[a-zA-Z]+)");
             Matcher m = p.matcher(smsSender);
 
             if (m != null) {


### PR DESCRIPTION
SMS Receiver processes the SMS If the SMS sender is like "AT-620012". So I removed ? in the regex to validate correctly.