### PR TITLE
Fix: replace the Transaction Number once SMS Receiver sets the correct transaction number from SMS

### DIFF
--- a/app/src/main/java/com/money/manager/ex/transactions/EditTransactionCommonFunctions.java
+++ b/app/src/main/java/com/money/manager/ex/transactions/EditTransactionCommonFunctions.java
@@ -751,7 +751,7 @@ public class EditTransactionCommonFunctions {
             cursor.close();
         });
 
-        if (!transactionEntity.hasId() && (new BehaviourSettings(getContext()).getAutoTransactionNumber())) {
+        if (!transactionEntity.hasId() && transactionEntity.getTransactionNumber().isEmpty() && (new BehaviourSettings(getContext()).getAutoTransactionNumber())) {
             viewHolder.btnTransNumber.callOnClick();
         }
     }


### PR DESCRIPTION
Added condition to check if transaction number is populated already when saving txn, if empty then it will be populated automatically else will be left as it is. In this way, whatever is set by SMS receiver will be retained