### PR TITLE
5.1.3 : Enable Fingerprint Authentication by default (ISSUE #2355)

### DIFF
--- a/app/src/main/java/com/money/manager/ex/settings/SecuritySettings.java
+++ b/app/src/main/java/com/money/manager/ex/settings/SecuritySettings.java
@@ -17,7 +17,7 @@ public class SecuritySettings extends SettingsBase {
     }
 
     public boolean getFingerprintAuthentication() {
-        return get(PreferenceConstants.PREF_FINGERPRINT, false);
+        return get(PreferenceConstants.PREF_FINGERPRINT, true);
     }
 
     public void setFingerprintAuthentication(boolean status) {

--- a/app/src/main/res/xml/preferences_security.xml
+++ b/app/src/main/res/xml/preferences_security.xml
@@ -32,7 +32,7 @@
 
     <SwitchPreference
         android:icon="@null"
-        android:defaultValue="false"
+        android:defaultValue="true"
         android:key="@string/preferences_fingerprint_auth_key"
         android:summary="@string/preferences_fingerprint_summary"
         android:title="@string/preferences_fingerprint_title" />

--- a/metadata/android/en-US/changelogs/1075.txt
+++ b/metadata/android/en-US/changelogs/1075.txt
@@ -1,3 +1,4 @@
 Fix SMS Receiver processing if the SMS sender name doesn't have the hyphen
 Fix Don't Replace the Transaction Number once the SMS Receiver sets the correct transaction number from SMS
 Fix cursor null in tagrepo
+Fix Enable Fingerprint Authentication by default


### PR DESCRIPTION
Enable Fingerprint Authentication by default, so existing users won't be affected.

Fix for https://github.com/moneymanagerex/android-money-manager-ex/issues/2355 