### PR TITLE
v5.1 : Added fix to clear the passcode set as "FingerprintAuthenticationSuccess"

### DIFF
--- a/app/src/main/java/com/money/manager/ex/home/MainActivity.java
+++ b/app/src/main/java/com/money/manager/ex/home/MainActivity.java
@@ -260,14 +260,27 @@ public class MainActivity
         if (!isAuthenticated) {
             Passcode passcode = new Passcode(getApplicationContext());
             if (passcode.hasPasscode() && !isInAuthentication) {
-                Intent intent = new Intent(this, PasscodeActivity.class);
-                // set action and data
-                intent.setAction(PasscodeActivity.INTENT_REQUEST_PASSWORD);
-                intent.putExtra(PasscodeActivity.INTENT_MESSAGE_TEXT, getString(R.string.enter_your_passcode));
-                intent.putExtra(PasscodeActivity.PASSCODE_REQUEST, String.valueOf(SecuritySettingsFragment.REQUEST_LOGIN_PASSCODE)); // passing zero as default value
-                // start activity
-                startActivityForResult(intent, RequestCodes.PASSCODE);
-                // set in authentication
+
+                //#2381 : Passcode issue after Android update
+                // remove the passcode which was set as "FingerprintAuthenticationSuccess"
+                if (passcode.getPasscode().equals("FingerprintAuthenticationSuccess")) {
+                    if (passcode.clearPasscode()) {
+                        new Core(this).alert(R.string.fingerprint_passcode_deactivated);
+                    }
+                    else {
+                        new Core(this).alert(R.string.passcode_not_update);
+                    }
+                } else {
+                    Intent intent = new Intent(this, PasscodeActivity.class);
+                    // set action and data
+                    intent.setAction(PasscodeActivity.INTENT_REQUEST_PASSWORD);
+                    intent.putExtra(PasscodeActivity.INTENT_MESSAGE_TEXT, getString(R.string.enter_your_passcode));
+                    intent.putExtra(PasscodeActivity.PASSCODE_REQUEST, String.valueOf(SecuritySettingsFragment.REQUEST_LOGIN_PASSCODE)); // passing zero as default value
+                    // start activity
+                    startActivityForResult(intent, RequestCodes.PASSCODE);
+                    // set in authentication
+                }
+
                 isInAuthentication = true;
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -309,6 +309,7 @@
     <string name="enter_your_previous_passcode">Enter your previous passcode</string>
     <!--<string name="passcode_update">passcode is updated</string>-->
     <string name="passcode_not_update">passcode is not updated</string>
+    <string name="fingerprint_passcode_deactivated">Security passcode was activated using Fingerprint Authentication, so the passcode has been deactivated automatically, please reactivate the passcode with numeric value</string>
     <string name="preferences_fingerprint_auth_key">Fingerprint Authentication Key</string>
     <string name="preferences_fingerprint_summary">Enable to use the Fingerprint authentication for login and disable passcode screen. However, user cannot use Fingerprint for activating or editing the passcode</string>
     <string name="preferences_fingerprint_title">Fingerprint Authentication</string>


### PR DESCRIPTION
v5.1 : Added fix to clear the passcode set as "FingerprintAuthenticationSuccess". Following msg will to shown in this case and passcode will be removed automatically.

Issue: #2381

<img width="108" alt="image" src="https://github.com/user-attachments/assets/e9c2cd64-3828-423d-8a28-2b56d5cf0137" />
