### PR TITLE
Missing CNAME file

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+android.moneymanagerex.org


### PR DESCRIPTION
website work under: https://moneymanagerex.org/android-money-manager-ex/
cname will permit to work as https://android.moneymanagerex.org

see: https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/troubleshooting-custom-domains-and-github-pages#cname-errors