### PR TITLE
Fix: Add missing initial date to account query

### DIFF
--- a/app/src/main/java/com/money/manager/ex/datalayer/AccountRepository.java
+++ b/app/src/main/java/com/money/manager/ex/datalayer/AccountRepository.java
@@ -51,7 +51,9 @@ public class AccountRepository
         return new String[] { ID_COLUMN + " AS _id", Account.ACCOUNTID, Account.ACCOUNTNAME,
                 Account.ACCOUNTTYPE, Account.ACCOUNTNUM, Account.STATUS, Account.NOTES,
                 Account.HELDAT, Account.WEBSITE, Account.CONTACTINFO, Account.ACCESSINFO,
-                Account.INITIALBAL, Account.FAVORITEACCT, Account.CURRENCYID };
+                Account.INITIALBAL, Account.FAVORITEACCT, Account.CURRENCYID ,
+                Account.INITIALDATE     // issue #2800 missing initial date in read
+        };
     }
 
     public String getTableName() {


### PR DESCRIPTION
close #2800 
add initial date during read (was missing, so every time set it to today but never store it :( )
