### PR TITLE
Add dark mode support to about screen

### DIFF
--- a/app/src/main/java/com/money/manager/ex/about/AboutActivity.java
+++ b/app/src/main/java/com/money/manager/ex/about/AboutActivity.java
@@ -26,8 +26,6 @@ import com.money.manager.ex.common.MmxBaseFragmentActivity;
 import androidx.annotation.NonNull;
 import androidx.viewpager2.widget.ViewPager2;
 
-import timber.log.Timber;
-
 /**
  * About the app
  */
@@ -75,12 +73,4 @@ public class AboutActivity
         mViewPager.setCurrentItem(savedInstanceState.getInt(BUNDLE_KEY_TABINDEX));
     }
 
-    @Override
-    protected void setTheme() {
-        try {
-            this.setTheme(R.style.Theme_Money_Manager_Light);
-        } catch (Exception e) {
-            Timber.e(e, "setting theme");
-        }
-    }
 }

--- a/app/src/main/java/com/money/manager/ex/about/AboutCreditsFragment.java
+++ b/app/src/main/java/com/money/manager/ex/about/AboutCreditsFragment.java
@@ -19,6 +19,8 @@ package com.money.manager.ex.about;
 
 import static com.money.manager.ex.R.raw.credits_thirdparty;
 
+import android.graphics.Color;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -27,6 +29,7 @@ import android.webkit.WebSettings;
 import android.webkit.WebView;
 
 import com.money.manager.ex.R;
+import com.money.manager.ex.core.UIHelper;
 import com.money.manager.ex.utils.MmxFileUtils;
 
 import androidx.annotation.NonNull;
@@ -59,6 +62,16 @@ public class AboutCreditsFragment extends Fragment {
         // Display Unicode characters.
         WebSettings settings = webView.getSettings();
         settings.setDefaultTextEncodingName("utf-8");
+
+        if (new UIHelper(requireContext()).isUsingDarkTheme()) {
+            webView.setBackgroundColor(Color.TRANSPARENT);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                settings.setAlgorithmicDarkeningAllowed(true);
+            } else {
+                //noinspection deprecation
+                settings.setForceDark(WebSettings.FORCE_DARK_ON);
+            }
+        }
 
         webView.loadData(MmxFileUtils.getRawAsString(getActivity().getApplicationContext(), credits_thirdparty),
                 "text/html; charset=utf-8", null);

--- a/app/src/main/res/layout/about_activity.xml
+++ b/app/src/main/res/layout/about_activity.xml
@@ -41,6 +41,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@+id/appbar"
-        android:background="@android:color/white"/>
+        android:background="?attr/theme_background_color"/>
 
 </RelativeLayout>

--- a/app/src/main/res/layout/about_content.xml
+++ b/app/src/main/res/layout/about_content.xml
@@ -33,7 +33,7 @@
             android:id="@+id/about_thirdsparty_credits"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:background="#FFF" />
+            />
     </LinearLayout>
 
 </ScrollView>


### PR DESCRIPTION
Fixes #2862

About screen was forcing light theme no matter what. Removed the hardcoded theme and added dark mode support for the credits view.