### PR TITLE
additional changes for #2810: Transaction list order is inconsistent for transactions created on the same day

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,6 +59,9 @@ android {
     }
 
     buildTypes {
+        release {
+            signingConfig signingConfigs.debug
+        }
         debug {
 //            applicationIdSuffix ".debug"
             versionNameSuffix "-debug-" + getCurrentBranch() + "-" + getVersionAsDate()

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,9 +59,6 @@ android {
     }
 
     buildTypes {
-        release {
-            signingConfig signingConfigs.debug
-        }
         debug {
 //            applicationIdSuffix ".debug"
             versionNameSuffix "-debug-" + getCurrentBranch() + "-" + getVersionAsDate()

--- a/app/src/main/java/com/money/manager/ex/common/AllDataListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/common/AllDataListFragment.java
@@ -329,10 +329,10 @@ public class AllDataListFragment
             }
 
             // set sort
-            String sort = "";
-            if (args != null && args.containsKey(KEY_ARGUMENTS_SORT)) {
-                sort = args.getString(KEY_ARGUMENTS_SORT);
-            } else {
+            String sort = (args != null) ? args.getString(KEY_ARGUMENTS_SORT) : null;
+
+            //#2810: Transaction list order is inconsistent for transactions created on the same day
+            if (!TextUtils.isEmpty(sort)) {
                 if ((new AppSettings(getContext())).getTransactionSort() == SORT_BY_DATE_DESC) {
                     sort = ((allData.getClass().equals(QueryAllData.class)) ? QueryAllData.Date : QueryMobileData.Date) + " DESC, " +
                             ((allData.getClass().equals(QueryAllData.class)) ? QueryAllData.ID : QueryMobileData.ID) + " DESC";

--- a/app/src/main/java/com/money/manager/ex/common/AllDataListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/common/AllDataListFragment.java
@@ -332,10 +332,10 @@ public class AllDataListFragment
             String sort = (args != null) ? args.getString(KEY_ARGUMENTS_SORT) : null;
 
             //#2810: Transaction list order is inconsistent for transactions created on the same day
-            // if sort is null, then alwasy consider as DESC
             if (!TextUtils.isEmpty(sort)) {
-                    sort = ((allData.getClass().equals(QueryAllData.class)) ? QueryAllData.Date : QueryMobileData.Date) + " DESC, " +
-                            ((allData.getClass().equals(QueryAllData.class)) ? QueryAllData.ID : QueryMobileData.ID) + " DESC";
+                String sortDirection = (new AppSettings(getContext())).getTransactionSort() == 0 ? "DESC" : "ASC";
+                    sort = ((allData.getClass().equals(QueryAllData.class)) ? QueryAllData.Date : QueryMobileData.Date) + " " + sortDirection + ", " +
+                            ((allData.getClass().equals(QueryAllData.class)) ? QueryAllData.ID : QueryMobileData.ID) + " " + sortDirection;
             }
 
             Select query = new Select(allData.getAllColumns())

--- a/app/src/main/java/com/money/manager/ex/common/AllDataListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/common/AllDataListFragment.java
@@ -332,6 +332,7 @@ public class AllDataListFragment
             String sort = (args != null) ? args.getString(KEY_ARGUMENTS_SORT) : null;
 
             //#2810: Transaction list order is inconsistent for transactions created on the same day
+            // if sort is null, then alwasy consider as DESC
             if (!TextUtils.isEmpty(sort)) {
                     sort = ((allData.getClass().equals(QueryAllData.class)) ? QueryAllData.Date : QueryMobileData.Date) + " DESC, " +
                             ((allData.getClass().equals(QueryAllData.class)) ? QueryAllData.ID : QueryMobileData.ID) + " DESC";

--- a/app/src/main/java/com/money/manager/ex/common/AllDataListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/common/AllDataListFragment.java
@@ -333,15 +333,8 @@ public class AllDataListFragment
 
             //#2810: Transaction list order is inconsistent for transactions created on the same day
             if (!TextUtils.isEmpty(sort)) {
-                if ((new AppSettings(getContext())).getTransactionSort() == SORT_BY_DATE_DESC) {
                     sort = ((allData.getClass().equals(QueryAllData.class)) ? QueryAllData.Date : QueryMobileData.Date) + " DESC, " +
                             ((allData.getClass().equals(QueryAllData.class)) ? QueryAllData.ID : QueryMobileData.ID) + " DESC";
-                }
-                if ((new AppSettings(getContext())).getTransactionSort() == SORT_BY_DATE_ASC) {
-                    sort = ((allData.getClass().equals(QueryAllData.class)) ? QueryAllData.Date : QueryMobileData.Date) + " ASC, " +
-                            ((allData.getClass().equals(QueryAllData.class)) ? QueryAllData.ID : QueryMobileData.ID) + " ASC";
-                }
-
             }
 
             Select query = new Select(allData.getAllColumns())

--- a/app/src/main/java/com/money/manager/ex/common/AllDataListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/common/AllDataListFragment.java
@@ -332,7 +332,7 @@ public class AllDataListFragment
             String sort = (args != null) ? args.getString(KEY_ARGUMENTS_SORT) : null;
 
             //#2810: Transaction list order is inconsistent for transactions created on the same day
-            if (!TextUtils.isEmpty(sort)) {
+            if (TextUtils.isEmpty(sort)) {
                 String sortDirection = (new AppSettings(getContext())).getTransactionSort() == 0 ? "DESC" : "ASC";
                     sort = ((allData.getClass().equals(QueryAllData.class)) ? QueryAllData.Date : QueryMobileData.Date) + " " + sortDirection + ", " +
                             ((allData.getClass().equals(QueryAllData.class)) ? QueryAllData.ID : QueryMobileData.ID) + " " + sortDirection;


### PR DESCRIPTION
additional changes for #2810: Transaction list order is inconsistent for transactions created on the same day