### PR TITLE
Disable stray FAB from reports

### DIFF
--- a/app/src/main/java/com/money/manager/ex/common/BaseListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/common/BaseListFragment.java
@@ -74,23 +74,27 @@ public abstract class BaseListFragment
 
         setupFloatingActionButton(view);
 
-        getListView().setOnScrollListener(new AbsListView.OnScrollListener() {
-            private boolean isFabVisible = true;
+        if (isFabAutoToggleEnabled()) {
+            getListView().setOnScrollListener(new AbsListView.OnScrollListener() {
+                private boolean isFabVisible = true;
 
-            @Override
-            public void onScrollStateChanged(AbsListView view, int scrollState) {
-            }
-
-            @Override
-            public void onScroll(AbsListView view, int firstVisibleItem, int visibleItemCount, int totalItemCount) {
-                if (firstVisibleItem > 0 && isFabVisible) {
-                    isFabVisible = false;
-                } else if (firstVisibleItem == 0 && !isFabVisible) {
-                    isFabVisible = true;
+                @Override
+                public void onScrollStateChanged(AbsListView view, int scrollState) {
                 }
-                setFabVisible(isFabVisible);
-            }
-        });
+
+                @Override
+                public void onScroll(AbsListView view, int firstVisibleItem, int visibleItemCount, int totalItemCount) {
+                    if (firstVisibleItem > 0 && isFabVisible) {
+                        isFabVisible = false;
+                    } else if (firstVisibleItem == 0 && !isFabVisible) {
+                        isFabVisible = true;
+                    }
+                    setFabVisible(isFabVisible);
+                }
+            });
+        } else {
+            setFabVisible(false);
+        }
     }
 
     private void setupMenuProviders() {
@@ -299,5 +303,9 @@ public abstract class BaseListFragment
                 }
             });
         }
+    }
+
+    protected boolean isFabAutoToggleEnabled() {
+        return true;
     }
 }

--- a/app/src/main/java/com/money/manager/ex/reports/BaseReportFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/BaseReportFragment.java
@@ -65,6 +65,11 @@ public abstract class BaseReportFragment
 
     @Inject Lazy<MmxDateTimeUtils> dateTimeUtilsLazy;
 
+    @Override
+    protected boolean isFabAutoToggleEnabled() {
+        return false;
+    }
+
     protected int mItemSelected = R.id.menu_all_time;
     protected String mWhereClause = null;
     protected Date mDateFrom = null;

--- a/app/src/main/java/com/money/manager/ex/reports/CategoriesReportFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/CategoriesReportFragment.java
@@ -72,9 +72,6 @@ public class CategoriesReportFragment
         setListAdapter(null);
         setSearchMenuVisible(true);
 
-        // disable fab issue #2504
-        setFabVisible(false);
-
         //create header view
         LinearLayout mListViewHeader = (LinearLayout) addListViewHeaderFooter(R.layout.item_generic_report_2_columns);
         TextView txtColumn1 = mListViewHeader.findViewById(R.id.textViewColumn1);

--- a/app/src/main/java/com/money/manager/ex/reports/PayeeReportFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/PayeeReportFragment.java
@@ -65,9 +65,6 @@ public class PayeeReportFragment
     public void onActivityCreated(Bundle savedInstanceState) {
         setListAdapter(null);
         setSearchMenuVisible(true);
-
-        // disable fab issue #2504
-        setFabVisible(false);
         //create header view
         mHeaderListView = (LinearLayout) addListViewHeaderFooter(R.layout.item_generic_report_2_columns);
         TextView txtColumn1 = mHeaderListView.findViewById(R.id.textViewColumn1);

--- a/app/src/main/java/com/money/manager/ex/reports/cashflow/CashFlowReportListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/cashflow/CashFlowReportListFragment.java
@@ -93,6 +93,11 @@ public class CashFlowReportListFragment
     private static final String BALANCE = "BALANCE";
     private static int monthInAdvance = 12;
 
+    @Override
+    protected boolean isFabAutoToggleEnabled() {
+        return false;
+    }
+
     private UIHelper ui;
     private MatrixCursor matrixCursor;
     String[] columnNames;
@@ -477,9 +482,6 @@ public class CashFlowReportListFragment
         setListShown(false);
 
 //        getLoaderManager().initLoader(ID_LOADER_REPORT, null, this);
-
-        // show floating button.
-        setFabVisible(false);
         // attachFloatingActionButtonToListView();
 
     }


### PR DESCRIPTION
When scrolling back to the top in some report screens, the FAB could still reappear. This change removes the FAB from reports where it is not meant to be available, making the behavior more consistent.