### PR TITLE
Refactor Currency Editing to use EditText for Currency Symbol

### DIFF
--- a/app/src/main/java/com/money/manager/ex/currency/CurrencyEditActivity.java
+++ b/app/src/main/java/com/money/manager/ex/currency/CurrencyEditActivity.java
@@ -16,22 +16,24 @@
  */
 package com.money.manager.ex.currency;
 
+import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.database.Cursor;
 import android.os.Bundle;
 import android.text.TextUtils;
-import android.widget.Spinner;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.widget.Toast;
 
 import com.money.manager.ex.Constants;
 import com.money.manager.ex.R;
 import com.money.manager.ex.common.MmxBaseFragmentActivity;
+import com.money.manager.ex.core.MenuHelper;
 import com.money.manager.ex.domainmodel.Currency;
 
 import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
-import java.util.Arrays;
 
 import timber.log.Timber;
 
@@ -82,8 +84,8 @@ public class CurrencyEditActivity
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.currency_edit_activity);
-        showStandardToolbarActions();
-
+//        showStandardToolbarActions();
+        setDisplayHomeAsUpEnabled(true);
 
         this.holder = CurrencyEditViewHolder.initialize(this);
 
@@ -123,15 +125,26 @@ public class CurrencyEditActivity
     }
 
     @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        new MenuHelper(this, menu).addSaveToolbarIcon();
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == MenuHelper.save) {
+            return onActionDoneClick();
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
 
         outState.putLong(KEY_CURRENCY_ID, mCurrencyId);
         outState.putString(KEY_CURRENCY_NAME, holder.edtCurrencyName.getText().toString());
-        if (holder.spinCurrencySymbol.getSelectedItemPosition() != Spinner.INVALID_POSITION) {
-            outState.putString(KEY_CURRENCY_SYMBOL, getResources()
-                .getStringArray(R.array.currencies_code)[holder.spinCurrencySymbol.getSelectedItemPosition()]);
-        }
+        outState.putString(KEY_CURRENCY_SYMBOL, holder.editCurrencySymbol.getText().toString());
         outState.putString(KEY_UNIT_NAME, holder.edtCurrencyName.getText().toString());
         outState.putString(KEY_CENTS_NAME, holder.edtCentsName.getText().toString());
         outState.putString(KEY_PREFIX_SYMBOL, holder.edtPrefix.getText().toString());
@@ -154,8 +167,7 @@ public class CurrencyEditActivity
         }
         // populate values
         holder.edtCurrencyName.setText(cursor.getString(cursor.getColumnIndexOrThrow(Currency.CURRENCYNAME)));
-        holder.spinCurrencySymbol.setSelection(Arrays.asList(getResources().getStringArray(R.array.currencies_code))
-            .indexOf(cursor.getString(cursor.getColumnIndexOrThrow(Currency.CURRENCY_SYMBOL))), true);
+        holder.editCurrencySymbol.setText(cursor.getString(cursor.getColumnIndexOrThrow(Currency.CURRENCY_SYMBOL)));
         holder.edtUnitName.setText(cursor.getString(cursor.getColumnIndexOrThrow(Currency.UNIT_NAME)));
         holder.edtCentsName.setText(cursor.getString(cursor.getColumnIndexOrThrow(Currency.CENT_NAME)));
         holder.edtPrefix.setText(cursor.getString(cursor.getColumnIndexOrThrow(Currency.PFX_SYMBOL)));
@@ -174,8 +186,7 @@ public class CurrencyEditActivity
         mCurrencyId = savedInstanceState.getLong(KEY_CURRENCY_ID);
 
         holder.edtCurrencyName.setText(savedInstanceState.getString(KEY_CURRENCY_NAME));
-        holder.spinCurrencySymbol.setSelection(Arrays.asList(getResources().getStringArray(R.array.currencies_code))
-            .indexOf(savedInstanceState.getString(KEY_CURRENCY_SYMBOL)), true);
+        holder.editCurrencySymbol.setText(savedInstanceState.getString(KEY_CURRENCY_SYMBOL));
         holder.edtUnitName.setText(savedInstanceState.getString(KEY_UNIT_NAME));
         holder.edtCentsName.setText(savedInstanceState.getString(KEY_CENTS_NAME));
         holder.edtPrefix.setText(savedInstanceState.getString(KEY_PREFIX_SYMBOL));
@@ -212,15 +223,8 @@ public class CurrencyEditActivity
         Currency currency = new Currency();
 
         currency.setName(holder.edtCurrencyName.getText().toString().trim());
-
-        if (holder.spinCurrencySymbol.getSelectedItemPosition() != Spinner.INVALID_POSITION) {
-            String code = getResources()
-                .getStringArray(R.array.currencies_code)[holder.spinCurrencySymbol.getSelectedItemPosition()];
-            currency.setCode(code);
-        }
-
+        currency.setCode(holder.editCurrencySymbol.getText().toString().trim());
         currency.setUnitName(holder.edtUnitName.getText().toString().trim());
-
         currency.setCentName(holder.edtCentsName.getText().toString().trim());
         currency.setPfxSymbol(holder.edtPrefix.getText().toString().trim());
         currency.setSfxSymbol(holder.edtSuffix.getText().toString().trim());

--- a/app/src/main/java/com/money/manager/ex/currency/CurrencyEditViewHolder.java
+++ b/app/src/main/java/com/money/manager/ex/currency/CurrencyEditViewHolder.java
@@ -17,7 +17,6 @@
 package com.money.manager.ex.currency;
 
 import android.widget.EditText;
-import android.widget.Spinner;
 
 import com.money.manager.ex.R;
 
@@ -31,7 +30,7 @@ public class CurrencyEditViewHolder {
         CurrencyEditViewHolder holder = new CurrencyEditViewHolder();
 
         holder.edtCurrencyName = activity.findViewById(R.id.editTextCurrencyName);
-        holder.spinCurrencySymbol = activity.findViewById(R.id.spinCurrencySymbol);
+        holder.editCurrencySymbol = activity.findViewById(R.id.editCurrencySymbol);
         holder.edtUnitName = activity.findViewById(R.id.editTextUnitName);
         holder.edtCentsName = activity.findViewById(R.id.editTextCentsName);
         holder.edtPrefix = activity.findViewById(R.id.editTextPrefixSymbol);
@@ -46,6 +45,6 @@ public class CurrencyEditViewHolder {
 
     public EditText edtCurrencyName, edtUnitName, edtCentsName, edtPrefix, edtSuffix,
         edtDecimal, edtGroup, edtScale, edtConversion;
-    public Spinner spinCurrencySymbol;
+    public EditText editCurrencySymbol;
 
 }

--- a/app/src/main/res/layout/currency_edit_activity.xml
+++ b/app/src/main/res/layout/currency_edit_activity.xml
@@ -56,18 +56,19 @@
             </com.google.android.material.textfield.TextInputLayout>
 
             <!-- Currency Symbol -->
-            <com.money.manager.ex.view.RobotoTextView
-                style="?attr/headerTextViewStyle"
+            <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:singleLine="true"
-                android:text="@string/currency_symbol" />
+                android:layout_height="wrap_content">
 
-            <Spinner
-                android:id="@+id/spinCurrencySymbol"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:entries="@array/currencies_code" />
+                <com.money.manager.ex.view.RobotoEditText
+                    android:id="@+id/editCurrencySymbol"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:ems="10"
+                    android:hint="@string/currency_symbol"
+                    android:maxLength="3"
+                    android:inputType="textCapCharacters" />
+            </com.google.android.material.textfield.TextInputLayout>
 
             <!-- Unit / Cents Name -->
             <LinearLayout
@@ -206,7 +207,5 @@
             </LinearLayout>
         </LinearLayout>
     </ScrollView>
-
-    <include layout="@layout/action_buttons" />
 
 </LinearLayout>


### PR DESCRIPTION
- UI Changes: Replaced the currency symbol Spinner with a EditText
- Removed the bottom action buttons layout in favor of toolbar actions.

issue #2858