### PR TITLE
Switch Income vs Expenses to BaseReportFragment date range picker

### DIFF
--- a/app/src/main/java/com/money/manager/ex/database/QueryReportIncomeVsExpenses.java
+++ b/app/src/main/java/com/money/manager/ex/database/QueryReportIncomeVsExpenses.java
@@ -33,6 +33,12 @@ public class QueryReportIncomeVsExpenses
         initialize(context, null);
     }
 
+    public QueryReportIncomeVsExpenses(Context context, String whereStatement) {
+        super("", DatasetType.QUERY, "report_income_vs_expenses");
+
+        initialize(context, whereStatement);
+    }
+
     @Override
     public String[] getAllColumns() {
         return new String[]{"0 AS _id",
@@ -45,14 +51,17 @@ public class QueryReportIncomeVsExpenses
 
     private void initialize(Context context, String whereStatement) {
         QueryMobileData mobileData = new QueryMobileData(context);
-        // add where statement
-        if(!TextUtils.isEmpty(whereStatement)) {
-            mobileData.setWhere(whereStatement);
-        }
         String mobileDataQuery = mobileData.getSource();
 
         // assemble the source statement by combining queries.
         String source = MmxFileUtils.getRawAsString(context, R.raw.report_income_vs_expenses);
+
+        if (!TextUtils.isEmpty(whereStatement)) {
+            String baseWhere = "where not(mobiledata.status = 'V')";
+            String filteredWhere = "where (" + whereStatement + ") and not(mobiledata.status = 'V')";
+            source = source.replace(baseWhere, filteredWhere);
+        }
+
         source = source.replace(Constants.MOBILE_DATA_PATTERN, mobileDataQuery);
         source = "(" + source + ") xxxx";
         this.setSource(source);

--- a/app/src/main/java/com/money/manager/ex/reports/IncomeVsExpensesListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/IncomeVsExpensesListFragment.java
@@ -305,14 +305,6 @@ public class IncomeVsExpensesListFragment
         return year + "-" + month;
     }
 
-    private boolean isBefore(int year, int month, int compareYear, int compareMonth) {
-        return year < compareYear || (year == compareYear && month < compareMonth);
-    }
-
-    private boolean isAfter(int year, int month, int compareYear, int compareMonth) {
-        return year > compareYear || (year == compareYear && month > compareMonth);
-    }
-
     private static class MonthValues {
         double income;
         double expenses;

--- a/app/src/main/java/com/money/manager/ex/reports/IncomeVsExpensesListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/IncomeVsExpensesListFragment.java
@@ -146,11 +146,20 @@ public class IncomeVsExpensesListFragment
     }
 
     private Cursor buildDisplayCursor(Cursor sourceCursor) {
-        Map<String, MonthValues> sourceValues = new HashMap<>();
-        Integer minYear = null;
-        Integer minMonth = null;
-        Integer maxYear = null;
-        Integer maxMonth = null;
+        SourceMonthData sourceData = extractSourceMonthData(sourceCursor);
+        MonthRange range = resolveDisplayRange(sourceData);
+        if (range == null) {
+            return sourceCursor;
+        }
+
+        ArrayList<RowValues> rows = buildMonthRows(sourceData.valuesByMonth, range);
+        appendYearSubtotals(rows);
+        sortRows(rows);
+        return toMatrixCursor(rows);
+    }
+
+    private SourceMonthData extractSourceMonthData(Cursor sourceCursor) {
+        SourceMonthData sourceData = new SourceMonthData();
 
         sourceCursor.moveToPosition(-1);
         while (sourceCursor.moveToNext()) {
@@ -164,70 +173,79 @@ public class IncomeVsExpensesListFragment
             monthValues.income = sourceCursor.getDouble(sourceCursor.getColumnIndexOrThrow(IncomeVsExpenseReportEntity.Income));
             monthValues.expenses = sourceCursor.getDouble(sourceCursor.getColumnIndexOrThrow(IncomeVsExpenseReportEntity.Expenses));
             monthValues.transfers = sourceCursor.getDouble(sourceCursor.getColumnIndexOrThrow(IncomeVsExpenseReportEntity.Transfers));
-            sourceValues.put(getMonthKey(year, month), monthValues);
+            sourceData.valuesByMonth.put(getMonthKey(year, month), monthValues);
 
-            if (minYear == null || isBefore(year, month, minYear, minMonth)) {
-                minYear = year;
-                minMonth = month;
-            }
-            if (maxYear == null || isAfter(year, month, maxYear, maxMonth)) {
-                maxYear = year;
-                maxMonth = month;
-            }
+            sourceData.updateBounds(year, month);
         }
 
-        Calendar startMonth = Calendar.getInstance();
-        Calendar endMonth = Calendar.getInstance();
+        return sourceData;
+    }
 
+    private MonthRange resolveDisplayRange(SourceMonthData sourceData) {
         if (mDateFrom != null && mDateTo != null) {
-            startMonth.setTime(mDateFrom);
-            startMonth.set(Calendar.DAY_OF_MONTH, 1);
-
-            endMonth.setTime(mDateTo);
-            endMonth.set(Calendar.DAY_OF_MONTH, 1);
-
+            Calendar startMonth = calendarMonthFromDate(mDateFrom);
+            Calendar endMonth = calendarMonthFromDate(mDateTo);
             if (startMonth.after(endMonth)) {
                 Calendar temp = (Calendar) startMonth.clone();
                 startMonth = endMonth;
                 endMonth = temp;
             }
-        } else {
-            if (minYear == null || maxYear == null) {
-                return sourceCursor;
-            }
-
-            startMonth.clear();
-            startMonth.set(minYear, minMonth - 1, 1);
-
-            endMonth.clear();
-            endMonth.set(maxYear, maxMonth - 1, 1);
+            return new MonthRange(startMonth, endMonth);
         }
 
-        ArrayList<RowValues> rows = new ArrayList<>();
-        Map<Integer, MonthValues> subtotalByYear = new HashMap<>();
+        if (!sourceData.hasBounds()) {
+            return null;
+        }
 
-        Calendar monthIterator = (Calendar) startMonth.clone();
-        while (!monthIterator.after(endMonth)) {
+        Calendar startMonth = Calendar.getInstance();
+        startMonth.clear();
+        startMonth.set(sourceData.minYear, sourceData.minMonth - 1, 1);
+
+        Calendar endMonth = Calendar.getInstance();
+        endMonth.clear();
+        endMonth.set(sourceData.maxYear, sourceData.maxMonth - 1, 1);
+
+        return new MonthRange(startMonth, endMonth);
+    }
+
+    private Calendar calendarMonthFromDate(java.util.Date date) {
+        Calendar month = Calendar.getInstance();
+        month.setTime(date);
+        month.set(Calendar.DAY_OF_MONTH, 1);
+        return month;
+    }
+
+    private ArrayList<RowValues> buildMonthRows(Map<String, MonthValues> valuesByMonth, MonthRange range) {
+        ArrayList<RowValues> rows = new ArrayList<>();
+        Calendar monthIterator = (Calendar) range.startMonth.clone();
+
+        while (!monthIterator.after(range.endMonth)) {
             int year = monthIterator.get(Calendar.YEAR);
             int month = monthIterator.get(Calendar.MONTH) + 1;
-
-            MonthValues monthValues = sourceValues.get(getMonthKey(year, month));
+            MonthValues monthValues = valuesByMonth.get(getMonthKey(year, month));
             if (monthValues == null) {
                 monthValues = new MonthValues();
             }
 
             rows.add(new RowValues(year, month, monthValues.income, monthValues.expenses, monthValues.transfers));
+            monthIterator.add(Calendar.MONTH, 1);
+        }
 
-            MonthValues subtotal = subtotalByYear.get(year);
+        return rows;
+    }
+
+    private void appendYearSubtotals(ArrayList<RowValues> rows) {
+        Map<Integer, MonthValues> subtotalByYear = new HashMap<>();
+        for (RowValues row : rows) {
+            MonthValues subtotal = subtotalByYear.get(row.year);
             if (subtotal == null) {
                 subtotal = new MonthValues();
-                subtotalByYear.put(year, subtotal);
+                subtotalByYear.put(row.year, subtotal);
             }
-            subtotal.income += monthValues.income;
-            subtotal.expenses += monthValues.expenses;
-            subtotal.transfers += monthValues.transfers;
 
-            monthIterator.add(Calendar.MONTH, 1);
+            subtotal.income += row.income;
+            subtotal.expenses += row.expenses;
+            subtotal.transfers += row.transfers;
         }
 
         for (Map.Entry<Integer, MonthValues> entry : subtotalByYear.entrySet()) {
@@ -236,7 +254,9 @@ public class IncomeVsExpensesListFragment
             rows.add(new RowValues(year, (int) IncomeVsExpensesActivity.SUBTOTAL_MONTH,
                     subtotal.income, subtotal.expenses, subtotal.transfers));
         }
+    }
 
+    private void sortRows(ArrayList<RowValues> rows) {
         rows.sort((left, right) -> {
             int yearCompare = Integer.compare(left.year, right.year);
             if (yearCompare == 0) {
@@ -254,7 +274,9 @@ public class IncomeVsExpensesListFragment
                 return yearCompare;
             });
         }
+    }
 
+    private MatrixCursor toMatrixCursor(ArrayList<RowValues> rows) {
         MatrixCursor displayCursor = new MatrixCursor(new String[]{
                 "_id",
                 IncomeVsExpenseReportEntity.YEAR,
@@ -295,6 +317,40 @@ public class IncomeVsExpensesListFragment
         double income;
         double expenses;
         double transfers;
+    }
+
+    private static class SourceMonthData {
+        final Map<String, MonthValues> valuesByMonth = new HashMap<>();
+        Integer minYear;
+        Integer minMonth;
+        Integer maxYear;
+        Integer maxMonth;
+
+        void updateBounds(int year, int month) {
+            if (minYear == null || (year < minYear || (year == minYear && month < minMonth))) {
+                minYear = year;
+                minMonth = month;
+            }
+
+            if (maxYear == null || (year > maxYear || (year == maxYear && month > maxMonth))) {
+                maxYear = year;
+                maxMonth = month;
+            }
+        }
+
+        boolean hasBounds() {
+            return minYear != null && minMonth != null && maxYear != null && maxMonth != null;
+        }
+    }
+
+    private static class MonthRange {
+        final Calendar startMonth;
+        final Calendar endMonth;
+
+        MonthRange(Calendar startMonth, Calendar endMonth) {
+            this.startMonth = startMonth;
+            this.endMonth = endMonth;
+        }
     }
 
     private static class RowValues {

--- a/app/src/main/java/com/money/manager/ex/reports/IncomeVsExpensesListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/IncomeVsExpensesListFragment.java
@@ -16,15 +16,14 @@
  */
 package com.money.manager.ex.reports;
 
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
+import android.database.MatrixCursor;
 import android.graphics.Typeface;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.text.TextUtils;
-import android.util.SparseBooleanArray;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -37,21 +36,14 @@ import androidx.core.content.ContextCompat;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
-import androidx.fragment.app.ListFragment;
-import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
 
 import com.google.common.primitives.Doubles;
-import com.google.common.primitives.Ints;
 import com.money.manager.ex.R;
-import com.money.manager.ex.common.MmxCursorLoader;
 import com.money.manager.ex.core.IntentFactory;
 import com.money.manager.ex.core.UIHelper;
 import com.money.manager.ex.currency.CurrencyService;
-import com.money.manager.ex.database.QueryMobileData;
 import com.money.manager.ex.database.QueryReportIncomeVsExpenses;
-import com.money.manager.ex.database.SQLDataSet;
-import com.money.manager.ex.datalayer.Select;
 import com.money.manager.ex.search.SearchParameters;
 import com.money.manager.ex.utils.MmxDate;
 import com.money.manager.ex.viewmodels.IncomeVsExpenseReportEntity;
@@ -59,48 +51,29 @@ import com.money.manager.ex.viewmodels.IncomeVsExpenseReportEntity;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.Collections;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
 import info.javaperformance.money.MoneyFactory;
 import timber.log.Timber;
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
-import androidx.core.view.MenuHost;
-import androidx.core.view.MenuProvider;
-import androidx.lifecycle.Lifecycle;
+import com.money.manager.ex.datalayer.Select;
 
 /**
  * Income/Expense Report, list.
  */
 public class IncomeVsExpensesListFragment
-    extends ListFragment
-    implements LoaderManager.LoaderCallbacks<Cursor> {
+    extends BaseReportFragment {
 
-    private static final int ID_LOADER_REPORT = 1;
-    private static final int ID_LOADER_YEARS = 2;
     private static final String SORT_ASCENDING = "ASC";
     private static final String SORT_DESCENDING = "DESC";
-    private static final String KEY_BUNDLE_YEAR = "IncomeVsExpensesListFragment:Years";
 
     private View mFooterListView;
-    private final SparseBooleanArray mYearsSelected = new SparseBooleanArray();
     private String mSort = SORT_ASCENDING;
-    private boolean mMenuProviderRegistered = false;
 
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        setupMenuProviders();
-
-        if (savedInstanceState != null && savedInstanceState.containsKey(KEY_BUNDLE_YEAR) &&
-                savedInstanceState.getIntArray(KEY_BUNDLE_YEAR) != null) {
-            for (int year : savedInstanceState.getIntArray(KEY_BUNDLE_YEAR)) {
-                mYearsSelected.put(year, true);
-            }
-        } else {
-            mYearsSelected.put(Calendar.getInstance().get(Calendar.YEAR), true);
-        }
 
         initializeListView();
 
@@ -114,16 +87,6 @@ public class IncomeVsExpensesListFragment
         // create adapter
         IncomeVsExpensesAdapter adapter = new IncomeVsExpensesAdapter(getActivity(), null);
         setListAdapter(adapter);
-        setListShown(false);
-        // start loader
-        //getLoaderManager().restartLoader(ID_LOADER_YEARS, null, this);
-        getLoaderManager().initLoader(ID_LOADER_YEARS, null, this);
-    }
-
-    @Override
-    public void onDestroyView() {
-        super.onDestroyView();
-        mMenuProviderRegistered = false;
     }
 
     // To remove Obsolete code we need to:
@@ -136,229 +99,262 @@ public class IncomeVsExpensesListFragment
 //
  //    }
 
-    // Loader
-    private void setupMenuProviders() {
-        if (mMenuProviderRegistered) return;
-
-        MenuHost menuHost = requireActivity();
-
-        // MenuProvider comune
-        menuHost.addMenuProvider(new MenuProvider() {
-            @Override
-            public void onCreateMenu(@NonNull Menu menu, @NonNull MenuInflater menuInflater) {
-                old_onCreateOptionsMenu(menu, menuInflater);
-            }
-
-            @Override
-            public boolean onMenuItemSelected(@NonNull MenuItem menuItem) {
-                return old_onOptionsItemSelected(menuItem);
-            }
-        }, getViewLifecycleOwner(), Lifecycle.State.RESUMED);
-
-        mMenuProviderRegistered = true;
-
-        // Chiamata al metodo che le classi derivate possono sovrascrivere
-        addCustomMenuProviders(menuHost);
-    }
-
-    // Metodo hook che le classi derivate possono sovrascrivere
-    protected void addCustomMenuProviders(MenuHost menuHost) {
-        // Implementazione di default vuota
-    }
-
-    @Override
-    public Loader<Cursor> onCreateLoader(int id, Bundle args) {
-        String selection = null;
-        Select query;
-
-        switch (id) {
-            case ID_LOADER_REPORT:
-                if (args != null && args.containsKey(KEY_BUNDLE_YEAR) && args.getString(KEY_BUNDLE_YEAR) != null) {
-                    selection = IncomeVsExpenseReportEntity.YEAR + " IN (" + args.getString(KEY_BUNDLE_YEAR) + ")";
-                    if (!TextUtils.isEmpty(selection)) {
-                        selection = "(" + selection + ")";
-                    }
-                }
-                // if don't have selection abort query
-                if (TextUtils.isEmpty(selection)) {
-                    selection = "1=2";
-                }
-                QueryReportIncomeVsExpenses report = new QueryReportIncomeVsExpenses(getActivity());
-                query = new Select(report.getAllColumns())
-                    .where(selection)
-                    .orderBy(IncomeVsExpenseReportEntity.YEAR + " " + mSort + ", " + IncomeVsExpenseReportEntity.Month + " " + mSort);
-
-                return new MmxCursorLoader(getActivity(), report.getUri(), query);
-
-            case ID_LOADER_YEARS:
-                QueryMobileData mobileData = new QueryMobileData(getContext());
-                selection = "SELECT DISTINCT Year as Year FROM " + mobileData.getSource() + " ORDER BY Year DESC";
-                query = new Select().where(selection);
-                return new MmxCursorLoader(getActivity(), new SQLDataSet().getUri(), query);
-        }
-        return null;
-    }
-
-    @Override
-    public void onLoaderReset(Loader<Cursor> loader) {
-//        ((IncomeVsExpensesAdapter) getListAdapter()).swapCursor(null);
-        ((IncomeVsExpensesAdapter) getListAdapter()).changeCursor(null);
-    }
 
     @Override
     public void onLoadFinished(Loader<Cursor> loader, Cursor data) {
-        switch (loader.getId()) {
-            case ID_LOADER_REPORT:
-//                ((IncomeVsExpensesAdapter) getListAdapter()).swapCursor(data);
-                ((IncomeVsExpensesAdapter) getListAdapter()).changeCursor(data);
+        if (loader.getId() == ID_LOADER) {
+            if (data == null) return;
 
-                if (isResumed()) {
-                    setListShown(true);
-                } else {
-                    setListShownNoAnimation(true);
+            Cursor displayCursor = buildDisplayCursor(data);
+            ((IncomeVsExpensesAdapter) getListAdapter()).changeCursor(displayCursor);
+
+            if (isResumed()) {
+                setListShown(true);
+            } else {
+                setListShownNoAnimation(true);
+            }
+
+            double income = 0;
+            double expenses = 0;
+
+            // move to first record #1539
+            displayCursor.moveToPosition(-1);
+
+            while (displayCursor.moveToNext()) {
+                if (displayCursor.getInt(displayCursor.getColumnIndexOrThrow(IncomeVsExpenseReportEntity.Month)) != IncomeVsExpensesActivity.SUBTOTAL_MONTH) {
+                    income += displayCursor.getDouble(displayCursor.getColumnIndexOrThrow(IncomeVsExpenseReportEntity.Income));
+                    expenses += displayCursor.getDouble(displayCursor.getColumnIndexOrThrow(IncomeVsExpenseReportEntity.Expenses));
                 }
-                // calculate income, expenses
-                double income = 0, expenses = 0;
-                if (data == null) return;
+            }
 
-                // move to first record #1539
-                data.moveToPosition(-1);
+            updateListViewFooter(mFooterListView, income, expenses);
+            if (displayCursor.getCount() > 0) {
+                getListView().removeFooterView(mFooterListView);
+                getListView().addFooterView(mFooterListView);
+            }
 
-                while (data.moveToNext()) {
-                    if (data.getInt(data.getColumnIndexOrThrow(IncomeVsExpenseReportEntity.Month)) != IncomeVsExpensesActivity.SUBTOTAL_MONTH) {
-                        income += data.getDouble(data.getColumnIndexOrThrow(IncomeVsExpenseReportEntity.Income));
-                        expenses += data.getDouble(data.getColumnIndexOrThrow(IncomeVsExpenseReportEntity.Expenses));
+            if (((IncomeVsExpensesActivity) getActivity()).mIsDualPanel) {
+                Handler handler = new Handler(Looper.getMainLooper());
+                handler.postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        showChart();
                     }
-                }
-                updateListViewFooter(mFooterListView, income, expenses);
-                if (data.getCount() > 0) {
-                    getListView().removeFooterView(mFooterListView);
-                    getListView().addFooterView(mFooterListView);
-                }
+                }, 1000);
+            }
+        }
+    }
 
-                if (((IncomeVsExpensesActivity) getActivity()).mIsDualPanel) {
-                    Handler handler = new Handler(Looper.getMainLooper());
-                    handler.postDelayed(new Runnable() {
-                        @Override
-                        public void run() {
-                            showChart();
-                        }
-                    }, 1000);
-                }
-                break;
+    private Cursor buildDisplayCursor(Cursor sourceCursor) {
+        Map<String, MonthValues> sourceValues = new HashMap<>();
+        Integer minYear = null;
+        Integer minMonth = null;
+        Integer maxYear = null;
+        Integer maxMonth = null;
 
-            case ID_LOADER_YEARS:
-                if (data != null && data.moveToFirst()) {
+        sourceCursor.moveToPosition(-1);
+        while (sourceCursor.moveToNext()) {
+            int year = sourceCursor.getInt(sourceCursor.getColumnIndexOrThrow(IncomeVsExpenseReportEntity.YEAR));
+            int month = sourceCursor.getInt(sourceCursor.getColumnIndexOrThrow(IncomeVsExpenseReportEntity.Month));
+            if (month == IncomeVsExpensesActivity.SUBTOTAL_MONTH) {
+                continue;
+            }
 
-                    while (!data.isAfterLast()) {
-                        int year = data.getInt(data.getColumnIndexOrThrow(IncomeVsExpenseReportEntity.YEAR));
-                        if (!mYearsSelected.get(year, false)) {
-                            mYearsSelected.put(year, false);
-                        }
-                        data.moveToNext();
-                    }
-                    startLoader();
+            MonthValues monthValues = new MonthValues();
+            monthValues.income = sourceCursor.getDouble(sourceCursor.getColumnIndexOrThrow(IncomeVsExpenseReportEntity.Income));
+            monthValues.expenses = sourceCursor.getDouble(sourceCursor.getColumnIndexOrThrow(IncomeVsExpenseReportEntity.Expenses));
+            monthValues.transfers = sourceCursor.getDouble(sourceCursor.getColumnIndexOrThrow(IncomeVsExpenseReportEntity.Transfers));
+            sourceValues.put(getMonthKey(year, month), monthValues);
+
+            if (minYear == null || isBefore(year, month, minYear, minMonth)) {
+                minYear = year;
+                minMonth = month;
+            }
+            if (maxYear == null || isAfter(year, month, maxYear, maxMonth)) {
+                maxYear = year;
+                maxMonth = month;
+            }
+        }
+
+        Calendar startMonth = Calendar.getInstance();
+        Calendar endMonth = Calendar.getInstance();
+
+        if (mDateFrom != null && mDateTo != null) {
+            startMonth.setTime(mDateFrom);
+            startMonth.set(Calendar.DAY_OF_MONTH, 1);
+
+            endMonth.setTime(mDateTo);
+            endMonth.set(Calendar.DAY_OF_MONTH, 1);
+
+            if (startMonth.after(endMonth)) {
+                Calendar temp = (Calendar) startMonth.clone();
+                startMonth = endMonth;
+                endMonth = temp;
+            }
+        } else {
+            if (minYear == null || maxYear == null) {
+                return sourceCursor;
+            }
+
+            startMonth.clear();
+            startMonth.set(minYear, minMonth - 1, 1);
+
+            endMonth.clear();
+            endMonth.set(maxYear, maxMonth - 1, 1);
+        }
+
+        ArrayList<RowValues> rows = new ArrayList<>();
+        Map<Integer, MonthValues> subtotalByYear = new HashMap<>();
+
+        Calendar monthIterator = (Calendar) startMonth.clone();
+        while (!monthIterator.after(endMonth)) {
+            int year = monthIterator.get(Calendar.YEAR);
+            int month = monthIterator.get(Calendar.MONTH) + 1;
+
+            MonthValues monthValues = sourceValues.get(getMonthKey(year, month));
+            if (monthValues == null) {
+                monthValues = new MonthValues();
+            }
+
+            rows.add(new RowValues(year, month, monthValues.income, monthValues.expenses, monthValues.transfers));
+
+            MonthValues subtotal = subtotalByYear.get(year);
+            if (subtotal == null) {
+                subtotal = new MonthValues();
+                subtotalByYear.put(year, subtotal);
+            }
+            subtotal.income += monthValues.income;
+            subtotal.expenses += monthValues.expenses;
+            subtotal.transfers += monthValues.transfers;
+
+            monthIterator.add(Calendar.MONTH, 1);
+        }
+
+        for (Map.Entry<Integer, MonthValues> entry : subtotalByYear.entrySet()) {
+            int year = entry.getKey();
+            MonthValues subtotal = entry.getValue();
+            rows.add(new RowValues(year, (int) IncomeVsExpensesActivity.SUBTOTAL_MONTH,
+                    subtotal.income, subtotal.expenses, subtotal.transfers));
+        }
+
+        rows.sort((left, right) -> {
+            int yearCompare = Integer.compare(left.year, right.year);
+            if (yearCompare == 0) {
+                return Integer.compare(left.month, right.month);
+            }
+            return yearCompare;
+        });
+
+        if (SORT_DESCENDING.equals(mSort)) {
+            rows.sort((left, right) -> {
+                int yearCompare = Integer.compare(right.year, left.year);
+                if (yearCompare == 0) {
+                    return Integer.compare(right.month, left.month);
                 }
+                return yearCompare;
+            });
+        }
+
+        MatrixCursor displayCursor = new MatrixCursor(new String[]{
+                "_id",
+                IncomeVsExpenseReportEntity.YEAR,
+                IncomeVsExpenseReportEntity.Month,
+                IncomeVsExpenseReportEntity.Income,
+                IncomeVsExpenseReportEntity.Expenses,
+                IncomeVsExpenseReportEntity.Transfers
+        });
+
+        long rowId = 0;
+        for (RowValues row : rows) {
+            displayCursor.addRow(new Object[]{
+                    rowId++,
+                    row.year,
+                    row.month,
+                    row.income,
+                    row.expenses,
+                    row.transfers
+            });
+        }
+
+        return displayCursor;
+    }
+
+    private String getMonthKey(int year, int month) {
+        return year + "-" + month;
+    }
+
+    private boolean isBefore(int year, int month, int compareYear, int compareMonth) {
+        return year < compareYear || (year == compareYear && month < compareMonth);
+    }
+
+    private boolean isAfter(int year, int month, int compareYear, int compareMonth) {
+        return year > compareYear || (year == compareYear && month > compareMonth);
+    }
+
+    private static class MonthValues {
+        double income;
+        double expenses;
+        double transfers;
+    }
+
+    private static class RowValues {
+        final int year;
+        final int month;
+        final double income;
+        final double expenses;
+        final double transfers;
+
+        RowValues(int year, int month, double income, double expenses, double transfers) {
+            this.year = year;
+            this.month = month;
+            this.income = income;
+            this.expenses = expenses;
+            this.transfers = transfers;
         }
     }
 
     // Menu
 
     public void old_onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
-        inflater.inflate(R.menu.menu_report_income_vs_expenses, menu);
-        // fix menu char
+        if (menu.findItem(R.id.menu_chart) == null) {
+            inflater.inflate(R.menu.menu_report, menu);
+        }
+
+        if (menu.findItem(R.id.menu_sort) == null) {
+            inflater.inflate(R.menu.menu_report_income_vs_expenses_sort, menu);
+        }
+
         MenuItem itemChart = menu.findItem(R.id.menu_chart);
         if (itemChart != null) {
             FragmentActivity activity = getActivity();
             if (activity instanceof IncomeVsExpensesActivity) {
                 itemChart.setVisible(!((IncomeVsExpensesActivity) activity).mIsDualPanel);
             }
+
+            UIHelper uiHelper = new UIHelper(getActivity());
+            itemChart.setIcon(uiHelper.resolveAttribute(R.attr.ic_action_bargraph));
+        }
+
+        MenuItem selectedSortItem = menu.findItem(SORT_ASCENDING.equals(mSort)
+                ? R.id.menu_sort_asceding
+                : R.id.menu_sort_desceding);
+        if (selectedSortItem != null) {
+            selectedSortItem.setChecked(true);
         }
     }
 
     public boolean old_onOptionsItemSelected(MenuItem item) {
-        if (item.getItemId() == android.R.id.home) {
-            getActivity().finish();
-        } else if (item.getItemId() == R.id.menu_sort_asceding || item.getItemId() == R.id.menu_sort_desceding) {
+        if (item.getItemId() == R.id.menu_sort_asceding || item.getItemId() == R.id.menu_sort_desceding) {
             mSort = item.getItemId() == R.id.menu_sort_asceding ? SORT_ASCENDING : SORT_DESCENDING;
-            startLoader();
+            startLoader(null);
             item.setChecked(true);
+            return true;
         } else if (item.getItemId() == R.id.menu_chart) {
             showChart();
-        } else if (item.getItemId() == R.id.menu_period) {
-            showDialogYears();
+            return true;
         }
 
         return false;
-    }
-
-    //
-
-    @Override
-    public void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
-        ArrayList<Integer> years = new ArrayList();
-        for (int i = 0; i < mYearsSelected.size(); i++) {
-            if (mYearsSelected.get(mYearsSelected.keyAt(i))) {
-                years.add(mYearsSelected.keyAt(i));
-            }
-        }
-
-        // ArrayUtils.toPrimitive(years.toArray(new Integer[0]))
-        int[] yearsArray = Ints.toArray(years);
-        outState.putIntArray(KEY_BUNDLE_YEAR, yearsArray);
-    }
-
-    // Other
-
-    public void showDialogYears() {
-        // Assuming mYearsSelected is a SparseBooleanArray
-        ArrayList<String> years = new ArrayList<>();
-        List<Integer> selected = new ArrayList<>();
-
-        for (int i = 0; i < mYearsSelected.size(); i++) {
-            years.add(String.valueOf(mYearsSelected.keyAt(i)));
-
-            if (mYearsSelected.valueAt(i)) {
-                // SparseBooleanArray will be always in ASC order, so reversing the selection index
-                selected.add(mYearsSelected.size()-(i+1));
-            }
-        }
-
-        // SparseBooleanArray will be always in ASC order, so using sort option
-        Collections.sort(years, Collections.reverseOrder());
-
-        // Convert years to CharSequence array
-        final CharSequence[] items = years.toArray(new CharSequence[years.size()]);
-        // Convert selected to boolean array
-        final boolean[] checkedItems = new boolean[items.length];
-        for (int i = 0; i < items.length; i++) {
-            checkedItems[i] = selected.contains(i);
-        }
-
-        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-        builder.setMultiChoiceItems(items, checkedItems, new DialogInterface.OnMultiChoiceClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which, boolean isChecked) {
-                        checkedItems[which] = isChecked;
-                    }
-                })
-                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        // Reset all years to false
-                        for (int i = 0; i < mYearsSelected.size(); i++) {
-                            mYearsSelected.put(mYearsSelected.keyAt(i), false);
-                        }
-                        // Set selected years
-                        for (int i = 0; i < checkedItems.length; i++) {
-                            mYearsSelected.put(mYearsSelected.keyAt(checkedItems.length-(i+1)), checkedItems[i]);
-                        }
-                        startLoader();
-                    }
-                })
-                .setNegativeButton(android.R.string.cancel, null)
-                .show();
     }
 
     // Private
@@ -441,22 +437,6 @@ public class IncomeVsExpensesListFragment
                 startActivity(intent);
             }
         });
-    }
-
-    /**
-     * Start loader with arrays year
-     *
-     */
-    private void startLoader() {
-        Bundle bundle = new Bundle();
-        String years = "";
-        for (int i = 0; i < mYearsSelected.size(); i++) {
-            if (mYearsSelected.get(mYearsSelected.keyAt(i))) {
-                years += (!TextUtils.isEmpty(years) ? ", " : "") + mYearsSelected.keyAt(i);
-            }
-        }
-        bundle.putString(KEY_BUNDLE_YEAR, years);
-        getLoaderManager().restartLoader(ID_LOADER_REPORT, bundle, this);
     }
 
     /**
@@ -577,5 +557,20 @@ public class IncomeVsExpensesListFragment
             }
             fragmentTransaction.commit();
         }
+    }
+
+    @Override
+    protected String prepareQuery(String whereClause) {
+        QueryReportIncomeVsExpenses report = new QueryReportIncomeVsExpenses(getActivity(), whereClause);
+
+        return new Select(report.getAllColumns())
+                .from(report.getSource())
+                .orderBy(IncomeVsExpenseReportEntity.YEAR + " " + mSort + ", " + IncomeVsExpenseReportEntity.Month + " " + mSort)
+                .toString();
+    }
+
+    @Override
+    public String getSubTitle() {
+        return null;
     }
 }

--- a/app/src/main/res/menu/menu_report_income_vs_expenses_sort.xml
+++ b/app/src/main/res/menu/menu_report_income_vs_expenses_sort.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2012-2026 The Android Money Manager Ex Project Team
+  ~
+  ~ This program is free software; you can redistribute it and/or
+  ~ modify it under the terms of the GNU General Public License
+  ~ as published by the Free Software Foundation; either version 3
+  ~ of the License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/menu_sort"
+        android:icon="?attr/ic_action_sort_1"
+        android:title="@string/sort"
+        app:showAsAction="always">
+        <menu>
+            <group android:checkableBehavior="single">
+                <item
+                    android:id="@+id/menu_sort_asceding"
+                    android:checked="true"
+                    android:title="@string/sort_by_ascending"/>
+                <item
+                    android:id="@+id/menu_sort_desceding"
+                    android:title="@string/sort_by_desceding"/>
+            </group>
+        </menu>
+    </item>
+
+</menu>


### PR DESCRIPTION
I found it a bit confusing that in the Income vs Expenses report the date picking was restricted to specific years and uses a different logic than the date picker in the other reports (e.g., payee). The date range picker from the BaseReportFragment is more flexible. So I switched the Income vs Expenses report to reuse that for more flexibility and consistency with the other reports. If you prefer the previous, feel free to tell me. It's just a suggestion.