### PR TITLE
Switch order of reports and change icon

### DIFF
--- a/app/src/main/java/com/money/manager/ex/home/MainActivity.java
+++ b/app/src/main/java/com/money/manager/ex/home/MainActivity.java
@@ -907,15 +907,15 @@ public class MainActivity
                 .withText(getString(R.string.menu_report_income_vs_expenses))
                 .withIconDrawable(uiHelper.getIcon(MMXIconFont.Icon.mmx_reports)
                         .color(iconColor)));
-        // CashFlow
-        childReports.add(new DrawerMenuItem().withId(R.id.menu_report_cashflow)
-                .withText(getString(R.string.menu_report_cashflow))
-                .withIconDrawable(uiHelper.getIcon(MMXIconFont.Icon.mmx_reports)
-                        .color(iconColor)));
         // summary of accounts
         childReports.add(new DrawerMenuItem().withId(R.id.menu_report_summary_of_accounts)
             .withText(getString(R.string.menu_report_summary_of_accounts))
             .withIconDrawable(uiHelper.getIcon(MMXIconFont.Icon.mmx_reports)
+                .color(iconColor)));
+        // CashFlow
+        childReports.add(new DrawerMenuItem().withId(R.id.menu_report_cashflow)
+            .withText(getString(R.string.menu_report_cashflow))
+            .withIconDrawable(uiHelper.getIcon(GoogleMaterial.Icon.gmd_show_chart)
                 .color(iconColor)));
 
         childItems.add(childReports);


### PR DESCRIPTION
This changes the icon of the cashflow report to an icon, which is more suitable for a line chart like the cashflow report is (the previous one looked like a bar chart). It also changes the order of the summary of accounts report and the cashflow report, such that similar reports are grouped semantically.