### PR TITLE
Refactor reports to use shared account/date filter helpers

### DIFF
--- a/app/src/main/java/com/money/manager/ex/common/BaseListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/common/BaseListFragment.java
@@ -100,6 +100,8 @@ public abstract class BaseListFragment
         menuHost.addMenuProvider(new MenuProvider() {
             @Override
             public void onCreateMenu(@NonNull Menu menu, @NonNull MenuInflater menuInflater) {
+                old_onCreateOptionsMenu(menu, menuInflater);
+
                 if (isSearchMenuVisible() && getActivity() != null && getActivity() instanceof AppCompatActivity) {
                     // Place an action bar item for searching.
                     final MenuItem itemSearch = menu.add(Menu.NONE, R.id.menu_query_mode, 1000, R.string.search);
@@ -130,7 +132,6 @@ public abstract class BaseListFragment
 
                     formatter.format(searchView);
                 }
-                old_onCreateOptionsMenu(menu, menuInflater);
             }
 
             @Override

--- a/app/src/main/java/com/money/manager/ex/database/QueryMobileData.java
+++ b/app/src/main/java/com/money/manager/ex/database/QueryMobileData.java
@@ -89,7 +89,7 @@ public class QueryMobileData
 
         // insert WHERE statement, filter.
         if(!TextUtils.isEmpty(where)) {
-            source += " WHERE ";
+			source += " AND ";
             source += where;
         }
 

--- a/app/src/main/java/com/money/manager/ex/database/QueryReportIncomeVsExpenses.java
+++ b/app/src/main/java/com/money/manager/ex/database/QueryReportIncomeVsExpenses.java
@@ -33,6 +33,12 @@ public class QueryReportIncomeVsExpenses
         initialize(context, null);
     }
 
+    public QueryReportIncomeVsExpenses(Context context, String whereStatement) {
+        super("", DatasetType.QUERY, "report_income_vs_expenses");
+
+        initialize(context, whereStatement);
+    }
+
     @Override
     public String[] getAllColumns() {
         return new String[]{"0 AS _id",

--- a/app/src/main/java/com/money/manager/ex/reports/AccountFilterSupport.java
+++ b/app/src/main/java/com/money/manager/ex/reports/AccountFilterSupport.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2012-2026 The Android Money Manager Ex Project Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.money.manager.ex.reports;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.database.Cursor;
+
+import com.money.manager.ex.R;
+import com.money.manager.ex.database.QueryAccountBills;
+import com.money.manager.ex.settings.LookAndFeelSettings;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import timber.log.Timber;
+
+public final class AccountFilterSupport {
+
+    private AccountFilterSupport() {
+    }
+
+    public interface OnAccountsSelectedListener {
+        void onAccountsSelected(List<Long> selectedIds);
+    }
+
+    public static boolean isAccountFilterMenuItem(int itemId) {
+        return itemId == R.id.menu_account_filter_all
+                || itemId == R.id.menu_account_filter_open
+                || itemId == R.id.menu_account_filter_favorite
+                || itemId == R.id.menu_account_filter_custom;
+    }
+
+    public static int getFilterMode(LookAndFeelSettings settings, String modePrefKey, int defaultMode) {
+        String storedValue = settings.get(modePrefKey, Integer.toString(defaultMode));
+        try {
+            return Integer.parseInt(storedValue);
+        } catch (Exception e) {
+            return defaultMode;
+        }
+    }
+
+    public static void saveFilterMode(LookAndFeelSettings settings, String modePrefKey, int mode) {
+        settings.set(modePrefKey, Integer.toString(mode));
+    }
+
+    public static ArrayList<Long> parseSelectedAccountIds(LookAndFeelSettings settings, String customPrefKey) {
+        String raw = settings.get(customPrefKey, "");
+        ArrayList<Long> result = new ArrayList<>();
+        if (raw.trim().isEmpty()) {
+            return result;
+        }
+
+        String[] ids = raw.split(",");
+        for (String id : ids) {
+            if (id.trim().isEmpty()) {
+                continue;
+            }
+            try {
+                result.add(Long.parseLong(id.trim()));
+            } catch (Exception e) {
+                Timber.w(e, "Invalid account id in filter: %s", id);
+            }
+        }
+        return result;
+    }
+
+    public static void saveSelectedAccountIds(LookAndFeelSettings settings, String customPrefKey, List<Long> ids) {
+        settings.set(customPrefKey, joinIds(ids));
+    }
+
+    public static String getSelectionForAccountIdColumn(int mode, List<Long> customAccountIds, String accountIdColumn) {
+        if (mode == R.id.menu_account_filter_all) {
+            return "";
+        }
+        if (mode == R.id.menu_account_filter_open) {
+            return accountIdColumn
+                    + " IN (SELECT ACCOUNTID FROM ACCOUNTLIST_V1 WHERE lower(STATUS) = 'open')";
+        }
+        if (mode == R.id.menu_account_filter_favorite) {
+            return accountIdColumn
+                    + " IN (SELECT ACCOUNTID FROM ACCOUNTLIST_V1 WHERE lower(FAVORITEACCT) = 'true')";
+        }
+        if (mode == R.id.menu_account_filter_custom) {
+            if (customAccountIds.isEmpty()) {
+                return "1=2";
+            }
+            return accountIdColumn + " IN (" + joinIds(customAccountIds) + ")";
+        }
+        return "";
+    }
+
+    public static void showAccountSelectionDialog(Context context, List<Long> selected,
+            OnAccountsSelectedListener listener) {
+        QueryAccountBills queryAccountBills = new QueryAccountBills(context);
+        Cursor cursor = context.getContentResolver().query(
+                queryAccountBills.getUri(),
+                null,
+                null,
+                null,
+                QueryAccountBills.ACCOUNTTYPE + ", upper(" + QueryAccountBills.ACCOUNTNAME + ")");
+
+        if (cursor == null) {
+            return;
+        }
+
+        final ArrayList<Long> accountIds = new ArrayList<>();
+        final ArrayList<String> accountNames = new ArrayList<>();
+        try {
+            while (cursor.moveToNext()) {
+                long accountId = cursor.getLong(cursor.getColumnIndexOrThrow(QueryAccountBills.ACCOUNTID));
+                String accountName = cursor.getString(cursor.getColumnIndexOrThrow(QueryAccountBills.ACCOUNTNAME));
+                accountIds.add(accountId);
+                accountNames.add(accountName);
+            }
+        } finally {
+            cursor.close();
+        }
+
+        final boolean[] checkedItems = new boolean[accountIds.size()];
+        for (int i = 0; i < accountIds.size(); i++) {
+            checkedItems[i] = selected.contains(accountIds.get(i));
+        }
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(context);
+        builder.setTitle(R.string.menu_account_filter_custom);
+        builder.setMultiChoiceItems(accountNames.toArray(new CharSequence[0]), checkedItems,
+                (dialog, which, isChecked) -> checkedItems[which] = isChecked);
+        builder.setPositiveButton(android.R.string.ok, (dialog, which) -> {
+            ArrayList<Long> selectedIds = new ArrayList<>();
+            for (int i = 0; i < accountIds.size(); i++) {
+                if (checkedItems[i]) {
+                    selectedIds.add(accountIds.get(i));
+                }
+            }
+            listener.onAccountsSelected(selectedIds);
+        });
+        builder.setNegativeButton(android.R.string.cancel, null);
+        builder.show();
+    }
+
+    private static String joinIds(List<Long> ids) {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < ids.size(); i++) {
+            if (i > 0) {
+                builder.append(',');
+            }
+            builder.append(ids.get(i));
+        }
+        return builder.toString();
+    }
+}

--- a/app/src/main/java/com/money/manager/ex/reports/AccountFilterSupport.java
+++ b/app/src/main/java/com/money/manager/ex/reports/AccountFilterSupport.java
@@ -104,6 +104,30 @@ public final class AccountFilterSupport {
         return "";
     }
 
+    public static String getSelectionForAccountIdColumn(int mode, LookAndFeelSettings settings,
+            String customPrefKey, String accountIdColumn) {
+        List<Long> selectedAccountIds = parseSelectedAccountIds(settings, customPrefKey);
+        return getSelectionForAccountIdColumn(mode, selectedAccountIds, accountIdColumn);
+    }
+
+    public static String getWhereClauseForAccountIdColumn(int mode, LookAndFeelSettings settings,
+            String customPrefKey, String accountIdColumn) {
+        String selection = getSelectionForAccountIdColumn(mode, settings, customPrefKey, accountIdColumn);
+        if (selection.trim().isEmpty()) {
+            return "";
+        }
+        return "WHERE " + selection;
+    }
+
+    public static void showAndPersistAccountSelectionDialog(Context context, LookAndFeelSettings settings,
+            String customPrefKey, Runnable onSelectionSaved) {
+        List<Long> selected = parseSelectedAccountIds(settings, customPrefKey);
+        showAccountSelectionDialog(context, selected, selectedIds -> {
+            saveSelectedAccountIds(settings, customPrefKey, selectedIds);
+            onSelectionSaved.run();
+        });
+    }
+
     public static void showAccountSelectionDialog(Context context, List<Long> selected,
             OnAccountsSelectedListener listener) {
         QueryAccountBills queryAccountBills = new QueryAccountBills(context);

--- a/app/src/main/java/com/money/manager/ex/reports/BaseReportFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/BaseReportFragment.java
@@ -16,15 +16,12 @@
  */
 package com.money.manager.ex.reports;
 
-import android.app.AlertDialog;
 import android.database.Cursor;
 import android.os.Bundle;
-import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.DatePicker;
 
 import androidx.annotation.NonNull;
 import androidx.core.view.MenuHost;
@@ -34,26 +31,19 @@ import androidx.lifecycle.Lifecycle;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
 
-import com.money.manager.ex.MmexApplication;
 import com.money.manager.ex.R;
 import com.money.manager.ex.common.BaseListFragment;
 import com.money.manager.ex.common.MmxCursorLoader;
-import com.money.manager.ex.core.InfoKeys;
 import com.money.manager.ex.database.SQLDataSet;
 import com.money.manager.ex.database.QueryAllData;
 import com.money.manager.ex.datalayer.Select;
-import com.money.manager.ex.servicelayer.InfoService;
 import com.money.manager.ex.settings.AppSettings;
 import com.money.manager.ex.settings.LookAndFeelSettings;
 import com.money.manager.ex.utils.MmxDate;
-import com.money.manager.ex.utils.MmxDateTimeUtils;
 
 import java.util.Date;
 import java.util.List;
 
-import javax.inject.Inject;
-
-import dagger.Lazy;
 import timber.log.Timber;
 
 public abstract class BaseReportFragment
@@ -66,21 +56,12 @@ public abstract class BaseReportFragment
     protected static final String KEY_FROM_DATE = "PayeeReportFragment:FromDate";
     protected static final String KEY_TO_DATE = "PayeeReportFragment:ToDate";
 
-    @Inject Lazy<MmxDateTimeUtils> dateTimeUtilsLazy;
-
     protected int mItemSelected = R.id.menu_all_time;
     protected String mWhereClause = null;
     protected Date mDateFrom = null;
     protected Date mDateTo = null;
 
     protected static final int ACCOUNT_FILTER_DEFAULT_MODE = R.id.menu_account_filter_open;
-
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
-        MmexApplication.getApp().iocComponent.inject(this);
-    }
 
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {

--- a/app/src/main/java/com/money/manager/ex/reports/BaseReportFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/BaseReportFragment.java
@@ -55,6 +55,7 @@ public abstract class BaseReportFragment
     protected static final String KEY_WHERE_CLAUSE = "PayeeReportFragment:WhereClause";
     protected static final String KEY_FROM_DATE = "PayeeReportFragment:FromDate";
     protected static final String KEY_TO_DATE = "PayeeReportFragment:ToDate";
+    protected static final int ACCOUNT_FILTER_DEFAULT_MODE = R.id.menu_account_filter_open;
 
     @Override
     protected boolean isFabAutoToggleEnabled() {
@@ -65,8 +66,6 @@ public abstract class BaseReportFragment
     protected String mWhereClause = null;
     protected Date mDateFrom = null;
     protected Date mDateTo = null;
-
-    protected static final int ACCOUNT_FILTER_DEFAULT_MODE = R.id.menu_account_filter_open;
 
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {

--- a/app/src/main/java/com/money/manager/ex/reports/BaseReportFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/BaseReportFragment.java
@@ -110,12 +110,9 @@ public abstract class BaseReportFragment
 
     @Override
     protected void addCustomMenuProviders(MenuHost menuHost) {
-        // add menu
         menuHost.addMenuProvider(new MenuProvider() {
             @Override
             public void onCreateMenu(@NonNull Menu menu, @NonNull MenuInflater menuInflater) {
-                // issue  #2841 multiple instance of period.
-                // move into original onCreateMenu
                 menuInflater.inflate(R.menu.menu_report, menu);
                 menuInflater.inflate(R.menu.menu_period_picker, menu);
 
@@ -136,7 +133,6 @@ public abstract class BaseReportFragment
                     }
                 }
 
-                //checked item
                 MenuItem item = menu.findItem(mItemSelected);
                 if (item != null) {
                     item.setChecked(true);
@@ -147,8 +143,6 @@ public abstract class BaseReportFragment
 
             @Override
             public boolean onMenuItemSelected(@NonNull MenuItem menuItem) {
-                MmxDate dateTime = MmxDate.newDate();
-
                 int itemId = menuItem.getItemId();
 
                 if (isAccountFilterEnabled() && isAccountFilterMenuItem(itemId)) {
@@ -163,93 +157,37 @@ public abstract class BaseReportFragment
                     return true;
                 }
 
-                if (itemId == R.id.menu_current_month) {
-                    mDateFrom = dateTime.firstDayOfMonth().toDate();
-                    mDateTo = dateTime.lastDayOfMonth().toDate();
-                } else if (itemId == R.id.menu_last_month) {
-                    mDateFrom = dateTime.minusMonths(1).firstDayOfMonth().toDate();
-                    mDateTo = dateTime.lastDayOfMonth().toDate();
-                } else if (itemId == R.id.menu_last_30_days) {
-                    mDateTo = dateTime.toDate();
-                    mDateFrom = dateTime.minusDays(30).toDate();
-                } else if (itemId == R.id.menu_current_year) {
-                    mDateFrom = dateTime.firstMonthOfYear().firstDayOfMonth().toDate();
-                    mDateTo = dateTime.lastMonthOfYear().lastDayOfMonth().toDate();
-                } else if (itemId == R.id.menu_last_year) {
-                    mDateFrom = dateTime.minusYears(1)
-                            .firstMonthOfYear()
-                            .firstDayOfMonth()
-                            .toDate();
-                    mDateTo = dateTime.lastMonthOfYear().lastDayOfMonth().toDate();
-// issue #1790 - handling financial year
-                } else if (itemId == R.id.menu_current_fin_year ||
-                        itemId == R.id.menu_last_fin_year) {
-                    InfoService infoService = new InfoService(getActivity());
-                    int financialYearStartDay = Integer.valueOf(infoService.getInfoValue(InfoKeys.FINANCIAL_YEAR_START_DAY, "1"));
-                    int financialYearStartMonth = Integer.valueOf(infoService.getInfoValue(InfoKeys.FINANCIAL_YEAR_START_MONTH, "1"))-1;
-                    if (financialYearStartMonth < 0) financialYearStartMonth = 0;
-                    MmxDate newDate = MmxDate.newDate();
-                    newDate.setDate(financialYearStartDay);
-                    newDate.setMonth(financialYearStartMonth);
-                    if (newDate.toDate().after(dateTime.toDate())) {
-                        // today is not part of current financial year, so we need to go back on year
-                        newDate.minusYears(1);
-                    }
-                    // right now newDAte is start of current fiscal year
-                    if (itemId == R.id.menu_last_fin_year) {
-                        newDate.minusYears(1);
-                    }
-                    mDateFrom = newDate.toDate();
-                    mDateTo = newDate.addYear(1).minusDays(1).toDate();
-                    Timber.v("FISCAL YEAR from: " + mDateFrom.toString() + " to: " + mDateTo.toString());
-                } else if (itemId == R.id.menu_all_time) {
+                if (itemId == R.id.menu_all_time) {
                     mDateFrom = null;
                     mDateTo = null;
                 } else if (itemId == R.id.menu_custom_dates) {
-                    // Check item
                     menuItem.setChecked(true);
                     mItemSelected = itemId;
-                    // Show custom dates dialog
                     showDialogCustomDates();
                     return true;
                 } else {
-                    return false;
+                    com.money.manager.ex.core.DateRange dateRange = ReportDateRangeSupport.resolveDateRange(requireContext(), itemId);
+                    if (dateRange == null) {
+                        return false;
+                    }
+                    mDateFrom = dateRange.dateFrom;
+                    mDateTo = dateRange.dateTo;
+                    Timber.v("Date range from: " + mDateFrom + " to: " + mDateTo);
                 }
 
-                String whereClause = null;
-                if (mDateFrom != null && mDateTo != null) {
-                    whereClause = QueryAllData.Date + " >= '" + new MmxDate(mDateFrom).toIsoDateString() +
-                            "' AND " + QueryAllData.Date + " <= '" + new MmxDate(mDateTo).toIsoDateString() + "'";
-                }
+                String whereClause = ReportDateRangeSupport.buildWhereClause(mDateFrom, mDateTo, QueryAllData.Date);
 
-                //check item
                 menuItem.setChecked(true);
-                mItemSelected = menuItem.getItemId();
+                mItemSelected = itemId;
 
-                //compose bundle
                 Bundle args = new Bundle();
                 args.putString(KEY_WHERE_CLAUSE, whereClause);
-
-                //starts loader
                 startLoader(args);
 
                 return true;
             }
         }, getViewLifecycleOwner(), Lifecycle.State.RESUMED);
     }
-
-//    public void old_onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
-//        super.old_onCreateOptionsMenu(menu, inflater);
-//        //inflate menu
-//    }
-
-//    public boolean old_onOptionsItemSelected(@NonNull MenuItem item) {
-////        MmxDateTimeUtils dateUtils = dateTimeUtilsLazy.get();
-//        return super.old_onOptionsItemSelected(item);
-//    }
-
-
-    // Loader events
 
     @Override
     public Loader<Cursor> onCreateLoader(int id, Bundle args) {
@@ -350,8 +288,8 @@ public abstract class BaseReportFragment
     protected String getAccountFilterSelection(String accountIdColumn) {
         LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
         int mode = getAccountFilterMode();
-        List<Long> customAccountIds = AccountFilterSupport.parseSelectedAccountIds(settings, getAccountFilterCustomPrefKey());
-        return AccountFilterSupport.getSelectionForAccountIdColumn(mode, customAccountIds, accountIdColumn);
+        return AccountFilterSupport.getSelectionForAccountIdColumn(
+                mode, settings, getAccountFilterCustomPrefKey(), accountIdColumn);
     }
 
     protected void onAccountFilterChanged() {
@@ -374,44 +312,18 @@ public abstract class BaseReportFragment
 
     private void showAccountSelectionDialog() {
         LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
-        List<Long> selected = AccountFilterSupport.parseSelectedAccountIds(settings, getAccountFilterCustomPrefKey());
-        AccountFilterSupport.showAccountSelectionDialog(requireContext(), selected, selectedIds -> {
-            AccountFilterSupport.saveSelectedAccountIds(settings, getAccountFilterCustomPrefKey(), selectedIds);
-            onAccountFilterChanged();
-        });
+        AccountFilterSupport.showAndPersistAccountSelectionDialog(
+                requireContext(), settings, getAccountFilterCustomPrefKey(), this::onAccountFilterChanged);
     }
 
     private void showDialogCustomDates() {
-        // Assuming mDateFrom, mDateTo, and KEY_WHERE_CLAUSE are class variables
-
-        // Inflate the custom view
-        View dialogView = LayoutInflater.from(getActivity()).inflate(R.layout.dialog_choose_date_report, null);
-        DatePicker fromDatePicker = dialogView.findViewById(R.id.datePickerFromDate);
-        DatePicker toDatePicker = dialogView.findViewById(R.id.datePickerToDate);
-
-        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-        builder.setView(dialogView)
-                .setPositiveButton(android.R.string.ok, (dialog, which) -> {
-                    mDateFrom = dateTimeUtilsLazy.get().from(fromDatePicker);
-                    mDateTo = dateTimeUtilsLazy.get().from(toDatePicker);
-
-                    String whereClause =
-                            QueryAllData.Date + ">='" + new MmxDate(mDateFrom).toIsoDateString() +
-                                    "' AND " +
-                                    QueryAllData.Date + "<='" + new MmxDate(mDateTo).toIsoDateString() + "'";
-
-                    Bundle args = new Bundle();
-                    args.putString(KEY_WHERE_CLAUSE, whereClause);
-
-                    startLoader(args);
-                })
-                .setNegativeButton(android.R.string.cancel, null)
-                .show();
-        // set date if is null
-        if (mDateFrom == null) mDateFrom = new MmxDate().today().toDate();
-        if (mDateTo == null) mDateTo = new MmxDate().today().toDate();
-
-        dateTimeUtilsLazy.get().setDatePicker(mDateFrom, fromDatePicker);
-        dateTimeUtilsLazy.get().setDatePicker(mDateTo, toDatePicker);
+        ReportDateRangeSupport.showCustomDateDialog(requireContext(), mDateFrom, mDateTo, (fromDate, toDate) -> {
+            mDateFrom = fromDate;
+            mDateTo = toDate;
+            String whereClause = ReportDateRangeSupport.buildWhereClause(mDateFrom, mDateTo, QueryAllData.Date);
+            Bundle args = new Bundle();
+            args.putString(KEY_WHERE_CLAUSE, whereClause);
+            startLoader(args);
+        });
     }
 }

--- a/app/src/main/java/com/money/manager/ex/reports/BaseReportFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/BaseReportFragment.java
@@ -56,8 +56,6 @@ public abstract class BaseReportFragment
     protected static final String KEY_FROM_DATE = "PayeeReportFragment:FromDate";
     protected static final String KEY_TO_DATE = "PayeeReportFragment:ToDate";
 
-    @Inject Lazy<MmxDateTimeUtils> dateTimeUtilsLazy;
-
     @Override
     protected boolean isFabAutoToggleEnabled() {
         return false;

--- a/app/src/main/java/com/money/manager/ex/reports/BaseReportFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/BaseReportFragment.java
@@ -39,14 +39,19 @@ import com.money.manager.ex.R;
 import com.money.manager.ex.common.BaseListFragment;
 import com.money.manager.ex.common.MmxCursorLoader;
 import com.money.manager.ex.core.InfoKeys;
+import com.money.manager.ex.database.QueryAccountBills;
 import com.money.manager.ex.database.SQLDataSet;
 import com.money.manager.ex.database.QueryAllData;
 import com.money.manager.ex.datalayer.Select;
 import com.money.manager.ex.servicelayer.InfoService;
+import com.money.manager.ex.settings.AppSettings;
+import com.money.manager.ex.settings.LookAndFeelSettings;
 import com.money.manager.ex.utils.MmxDate;
 import com.money.manager.ex.utils.MmxDateTimeUtils;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 import javax.inject.Inject;
 
@@ -69,6 +74,8 @@ public abstract class BaseReportFragment
     protected String mWhereClause = null;
     protected Date mDateFrom = null;
     protected Date mDateTo = null;
+
+    protected static final int ACCOUNT_FILTER_DEFAULT_MODE = R.id.menu_account_filter_open;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -113,6 +120,24 @@ public abstract class BaseReportFragment
                 // move into original onCreateMenu
                 menuInflater.inflate(R.menu.menu_report, menu);
                 menuInflater.inflate(R.menu.menu_period_picker, menu);
+
+                if (isPeriodPickerActionVisible()) {
+                    MenuItem periodItem = menu.findItem(R.id.menu_period);
+                    if (periodItem != null) {
+                        periodItem.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
+                    }
+                }
+
+                if (isAccountFilterEnabled() && menu.findItem(R.id.menu_account_filter) == null) {
+                    menuInflater.inflate(R.menu.menu_report_account_filter, menu);
+
+                    int selectedMode = getAccountFilterMode();
+                    MenuItem selectedItem = menu.findItem(selectedMode);
+                    if (selectedItem != null) {
+                        selectedItem.setChecked(true);
+                    }
+                }
+
                 //checked item
                 MenuItem item = menu.findItem(mItemSelected);
                 if (item != null) {
@@ -127,6 +152,18 @@ public abstract class BaseReportFragment
                 MmxDate dateTime = MmxDate.newDate();
 
                 int itemId = menuItem.getItemId();
+
+                if (isAccountFilterEnabled() && isAccountFilterMenuItem(itemId)) {
+                    menuItem.setChecked(true);
+                    saveAccountFilterMode(itemId);
+
+                    if (itemId == R.id.menu_account_filter_custom) {
+                        showAccountSelectionDialog();
+                    } else {
+                        onAccountFilterChanged();
+                    }
+                    return true;
+                }
 
                 if (itemId == R.id.menu_current_month) {
                     mDateFrom = dateTime.firstDayOfMonth().toDate();
@@ -294,6 +331,175 @@ public abstract class BaseReportFragment
 
     protected String getWhereClause() {
         return mWhereClause;
+    }
+
+    protected boolean isAccountFilterEnabled() {
+        return false;
+    }
+
+    protected boolean isPeriodPickerActionVisible() {
+        return false;
+    }
+
+    protected String getAccountFilterModePrefKey() {
+        return getClass().getSimpleName() + ":FilterMode";
+    }
+
+    protected String getAccountFilterCustomPrefKey() {
+        return getClass().getSimpleName() + ":FilterCustom";
+    }
+
+    protected String getAccountFilterSelection(String accountIdColumn) {
+        AccountFilter filter = getAccountFilter();
+        if (filter.mode == R.id.menu_account_filter_all) {
+            return "";
+        }
+        if (filter.mode == R.id.menu_account_filter_open) {
+            return accountIdColumn
+                    + " IN (SELECT ACCOUNTID FROM ACCOUNTLIST_V1 WHERE lower(STATUS) = 'open')";
+        }
+        if (filter.mode == R.id.menu_account_filter_favorite) {
+            return accountIdColumn
+                    + " IN (SELECT ACCOUNTID FROM ACCOUNTLIST_V1 WHERE lower(FAVORITEACCT) = 'true')";
+        }
+        if (filter.mode == R.id.menu_account_filter_custom) {
+            if (filter.customAccountIds.isEmpty()) {
+                return "1=2";
+            }
+            return accountIdColumn + " IN (" + joinIds(filter.customAccountIds) + ")";
+        }
+        return "";
+    }
+
+    protected void onAccountFilterChanged() {
+        startLoader(new Bundle());
+    }
+
+    private boolean isAccountFilterMenuItem(int itemId) {
+        return itemId == R.id.menu_account_filter_all
+            || itemId == R.id.menu_account_filter_open
+            || itemId == R.id.menu_account_filter_favorite
+            || itemId == R.id.menu_account_filter_custom;
+    }
+
+    private int getAccountFilterMode() {
+        LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
+        String storedValue = settings.get(getAccountFilterModePrefKey(), Integer.toString(ACCOUNT_FILTER_DEFAULT_MODE));
+        try {
+            return Integer.parseInt(storedValue);
+        } catch (Exception e) {
+            return ACCOUNT_FILTER_DEFAULT_MODE;
+        }
+    }
+
+    private void saveAccountFilterMode(int mode) {
+        LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
+        settings.set(getAccountFilterModePrefKey(), Integer.toString(mode));
+    }
+
+    private AccountFilter getAccountFilter() {
+        int mode = getAccountFilterMode();
+        List<Long> customAccountIds = parseSelectedAccountIds();
+        return new AccountFilter(mode, customAccountIds);
+    }
+
+    private void showAccountSelectionDialog() {
+        ArrayList<Long> selected = new ArrayList<>(parseSelectedAccountIds());
+
+        QueryAccountBills queryAccountBills = new QueryAccountBills(requireContext());
+        Cursor cursor = requireContext().getContentResolver().query(
+                queryAccountBills.getUri(),
+                null,
+                null,
+                null,
+                QueryAccountBills.ACCOUNTTYPE + ", upper(" + QueryAccountBills.ACCOUNTNAME + ")");
+
+        if (cursor == null) {
+            return;
+        }
+
+        final ArrayList<Long> accountIds = new ArrayList<>();
+        final ArrayList<String> accountNames = new ArrayList<>();
+        try {
+            while (cursor.moveToNext()) {
+                long accountId = cursor.getLong(cursor.getColumnIndexOrThrow(QueryAccountBills.ACCOUNTID));
+                String accountName = cursor.getString(cursor.getColumnIndexOrThrow(QueryAccountBills.ACCOUNTNAME));
+                accountIds.add(accountId);
+                accountNames.add(accountName);
+            }
+        } finally {
+            cursor.close();
+        }
+
+        final boolean[] checkedItems = new boolean[accountIds.size()];
+        for (int i = 0; i < accountIds.size(); i++) {
+            checkedItems[i] = selected.contains(accountIds.get(i));
+        }
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(requireContext());
+        builder.setTitle(R.string.menu_account_filter_custom);
+        builder.setMultiChoiceItems(accountNames.toArray(new CharSequence[0]), checkedItems,
+                (dialog, which, isChecked) -> checkedItems[which] = isChecked);
+        builder.setPositiveButton(android.R.string.ok, (dialog, which) -> {
+            ArrayList<Long> selectedIds = new ArrayList<>();
+            for (int i = 0; i < accountIds.size(); i++) {
+                if (checkedItems[i]) {
+                    selectedIds.add(accountIds.get(i));
+                }
+            }
+            saveSelectedAccountIds(selectedIds);
+            onAccountFilterChanged();
+        });
+        builder.setNegativeButton(android.R.string.cancel, null);
+        builder.show();
+    }
+
+    private ArrayList<Long> parseSelectedAccountIds() {
+        LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
+        String raw = settings.get(getAccountFilterCustomPrefKey(), "");
+        ArrayList<Long> result = new ArrayList<>();
+        if (raw.trim().isEmpty()) {
+            return result;
+        }
+
+        String[] ids = raw.split(",");
+        for (String id : ids) {
+            if (id.trim().isEmpty()) {
+                continue;
+            }
+            try {
+                result.add(Long.parseLong(id.trim()));
+            } catch (Exception e) {
+                Timber.w(e, "Invalid account id in filter: %s", id);
+            }
+        }
+        return result;
+    }
+
+    private void saveSelectedAccountIds(List<Long> ids) {
+        LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
+        settings.set(getAccountFilterCustomPrefKey(), joinIds(ids));
+    }
+
+    private String joinIds(List<Long> ids) {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < ids.size(); i++) {
+            if (i > 0) {
+                builder.append(',');
+            }
+            builder.append(ids.get(i));
+        }
+        return builder.toString();
+    }
+
+    private static final class AccountFilter {
+        final int mode;
+        final List<Long> customAccountIds;
+
+        AccountFilter(int mode, List<Long> customAccountIds) {
+            this.mode = mode;
+            this.customAccountIds = customAccountIds;
+        }
     }
 
     private void showDialogCustomDates() {

--- a/app/src/main/java/com/money/manager/ex/reports/BaseReportFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/BaseReportFragment.java
@@ -39,7 +39,6 @@ import com.money.manager.ex.R;
 import com.money.manager.ex.common.BaseListFragment;
 import com.money.manager.ex.common.MmxCursorLoader;
 import com.money.manager.ex.core.InfoKeys;
-import com.money.manager.ex.database.QueryAccountBills;
 import com.money.manager.ex.database.SQLDataSet;
 import com.money.manager.ex.database.QueryAllData;
 import com.money.manager.ex.datalayer.Select;
@@ -49,7 +48,6 @@ import com.money.manager.ex.settings.LookAndFeelSettings;
 import com.money.manager.ex.utils.MmxDate;
 import com.money.manager.ex.utils.MmxDateTimeUtils;
 
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -350,25 +348,10 @@ public abstract class BaseReportFragment
     }
 
     protected String getAccountFilterSelection(String accountIdColumn) {
-        AccountFilter filter = getAccountFilter();
-        if (filter.mode == R.id.menu_account_filter_all) {
-            return "";
-        }
-        if (filter.mode == R.id.menu_account_filter_open) {
-            return accountIdColumn
-                    + " IN (SELECT ACCOUNTID FROM ACCOUNTLIST_V1 WHERE lower(STATUS) = 'open')";
-        }
-        if (filter.mode == R.id.menu_account_filter_favorite) {
-            return accountIdColumn
-                    + " IN (SELECT ACCOUNTID FROM ACCOUNTLIST_V1 WHERE lower(FAVORITEACCT) = 'true')";
-        }
-        if (filter.mode == R.id.menu_account_filter_custom) {
-            if (filter.customAccountIds.isEmpty()) {
-                return "1=2";
-            }
-            return accountIdColumn + " IN (" + joinIds(filter.customAccountIds) + ")";
-        }
-        return "";
+        LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
+        int mode = getAccountFilterMode();
+        List<Long> customAccountIds = AccountFilterSupport.parseSelectedAccountIds(settings, getAccountFilterCustomPrefKey());
+        return AccountFilterSupport.getSelectionForAccountIdColumn(mode, customAccountIds, accountIdColumn);
     }
 
     protected void onAccountFilterChanged() {
@@ -376,130 +359,26 @@ public abstract class BaseReportFragment
     }
 
     private boolean isAccountFilterMenuItem(int itemId) {
-        return itemId == R.id.menu_account_filter_all
-            || itemId == R.id.menu_account_filter_open
-            || itemId == R.id.menu_account_filter_favorite
-            || itemId == R.id.menu_account_filter_custom;
+        return AccountFilterSupport.isAccountFilterMenuItem(itemId);
     }
 
     private int getAccountFilterMode() {
         LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
-        String storedValue = settings.get(getAccountFilterModePrefKey(), Integer.toString(ACCOUNT_FILTER_DEFAULT_MODE));
-        try {
-            return Integer.parseInt(storedValue);
-        } catch (Exception e) {
-            return ACCOUNT_FILTER_DEFAULT_MODE;
-        }
+        return AccountFilterSupport.getFilterMode(settings, getAccountFilterModePrefKey(), ACCOUNT_FILTER_DEFAULT_MODE);
     }
 
     private void saveAccountFilterMode(int mode) {
         LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
-        settings.set(getAccountFilterModePrefKey(), Integer.toString(mode));
-    }
-
-    private AccountFilter getAccountFilter() {
-        int mode = getAccountFilterMode();
-        List<Long> customAccountIds = parseSelectedAccountIds();
-        return new AccountFilter(mode, customAccountIds);
+        AccountFilterSupport.saveFilterMode(settings, getAccountFilterModePrefKey(), mode);
     }
 
     private void showAccountSelectionDialog() {
-        ArrayList<Long> selected = new ArrayList<>(parseSelectedAccountIds());
-
-        QueryAccountBills queryAccountBills = new QueryAccountBills(requireContext());
-        Cursor cursor = requireContext().getContentResolver().query(
-                queryAccountBills.getUri(),
-                null,
-                null,
-                null,
-                QueryAccountBills.ACCOUNTTYPE + ", upper(" + QueryAccountBills.ACCOUNTNAME + ")");
-
-        if (cursor == null) {
-            return;
-        }
-
-        final ArrayList<Long> accountIds = new ArrayList<>();
-        final ArrayList<String> accountNames = new ArrayList<>();
-        try {
-            while (cursor.moveToNext()) {
-                long accountId = cursor.getLong(cursor.getColumnIndexOrThrow(QueryAccountBills.ACCOUNTID));
-                String accountName = cursor.getString(cursor.getColumnIndexOrThrow(QueryAccountBills.ACCOUNTNAME));
-                accountIds.add(accountId);
-                accountNames.add(accountName);
-            }
-        } finally {
-            cursor.close();
-        }
-
-        final boolean[] checkedItems = new boolean[accountIds.size()];
-        for (int i = 0; i < accountIds.size(); i++) {
-            checkedItems[i] = selected.contains(accountIds.get(i));
-        }
-
-        AlertDialog.Builder builder = new AlertDialog.Builder(requireContext());
-        builder.setTitle(R.string.menu_account_filter_custom);
-        builder.setMultiChoiceItems(accountNames.toArray(new CharSequence[0]), checkedItems,
-                (dialog, which, isChecked) -> checkedItems[which] = isChecked);
-        builder.setPositiveButton(android.R.string.ok, (dialog, which) -> {
-            ArrayList<Long> selectedIds = new ArrayList<>();
-            for (int i = 0; i < accountIds.size(); i++) {
-                if (checkedItems[i]) {
-                    selectedIds.add(accountIds.get(i));
-                }
-            }
-            saveSelectedAccountIds(selectedIds);
+        LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
+        List<Long> selected = AccountFilterSupport.parseSelectedAccountIds(settings, getAccountFilterCustomPrefKey());
+        AccountFilterSupport.showAccountSelectionDialog(requireContext(), selected, selectedIds -> {
+            AccountFilterSupport.saveSelectedAccountIds(settings, getAccountFilterCustomPrefKey(), selectedIds);
             onAccountFilterChanged();
         });
-        builder.setNegativeButton(android.R.string.cancel, null);
-        builder.show();
-    }
-
-    private ArrayList<Long> parseSelectedAccountIds() {
-        LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
-        String raw = settings.get(getAccountFilterCustomPrefKey(), "");
-        ArrayList<Long> result = new ArrayList<>();
-        if (raw.trim().isEmpty()) {
-            return result;
-        }
-
-        String[] ids = raw.split(",");
-        for (String id : ids) {
-            if (id.trim().isEmpty()) {
-                continue;
-            }
-            try {
-                result.add(Long.parseLong(id.trim()));
-            } catch (Exception e) {
-                Timber.w(e, "Invalid account id in filter: %s", id);
-            }
-        }
-        return result;
-    }
-
-    private void saveSelectedAccountIds(List<Long> ids) {
-        LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
-        settings.set(getAccountFilterCustomPrefKey(), joinIds(ids));
-    }
-
-    private String joinIds(List<Long> ids) {
-        StringBuilder builder = new StringBuilder();
-        for (int i = 0; i < ids.size(); i++) {
-            if (i > 0) {
-                builder.append(',');
-            }
-            builder.append(ids.get(i));
-        }
-        return builder.toString();
-    }
-
-    private static final class AccountFilter {
-        final int mode;
-        final List<Long> customAccountIds;
-
-        AccountFilter(int mode, List<Long> customAccountIds) {
-            this.mode = mode;
-            this.customAccountIds = customAccountIds;
-        }
     }
 
     private void showDialogCustomDates() {

--- a/app/src/main/java/com/money/manager/ex/reports/BaseReportFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/BaseReportFragment.java
@@ -334,11 +334,11 @@ public abstract class BaseReportFragment
     }
 
     protected boolean isAccountFilterEnabled() {
-        return false;
+        return true;
     }
 
     protected boolean isPeriodPickerActionVisible() {
-        return false;
+        return true;
     }
 
     protected String getAccountFilterModePrefKey() {

--- a/app/src/main/java/com/money/manager/ex/reports/CategoriesReportFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/CategoriesReportFragment.java
@@ -241,6 +241,10 @@ public class CategoriesReportFragment
                 " AND " +
                 QueryMobileData.ACCOUNTTYPE + "<>'"+ AccountTypes.SHARES.toString()  +"' AND " +
                 QueryMobileData.TOACCOUNTTYPE + "<>'"+ AccountTypes.SHARES.toString() +"'" ;
+        String accountFilterSelection = getAccountFilterSelection(QueryMobileData.ACCOUNTID);
+        if (!TextUtils.isEmpty(accountFilterSelection)) {
+            selection += " AND " + accountFilterSelection;
+        }
         if (!TextUtils.isEmpty(whereClause)) {
             selection += " AND " + whereClause;
         }

--- a/app/src/main/java/com/money/manager/ex/reports/IncomeVsExpensesListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/IncomeVsExpensesListFragment.java
@@ -62,6 +62,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
 import info.javaperformance.money.MoneyFactory;
@@ -80,15 +81,18 @@ public class IncomeVsExpensesListFragment
     implements LoaderManager.LoaderCallbacks<Cursor> {
 
     private static final int ID_LOADER_REPORT = 1;
-    private static final int ID_LOADER_YEARS = 2;
     private static final String SORT_ASCENDING = "ASC";
     private static final String SORT_DESCENDING = "DESC";
-    private static final String KEY_BUNDLE_YEAR = "IncomeVsExpensesListFragment:Years";
+    private static final String KEY_BUNDLE_DATE_FROM = "IncomeVsExpensesListFragment:DateFrom";
+    private static final String KEY_BUNDLE_DATE_TO = "IncomeVsExpensesListFragment:DateTo";
+    private static final String KEY_BUNDLE_ITEM_SELECTED = "IncomeVsExpensesListFragment:ItemSelected";
     private static final String PREF_FILTER_MODE = "IncomeVsExpensesFilterMode";
     private static final String PREF_FILTER_CUSTOM = "IncomeVsExpensesFilterCustom";
 
     private View mFooterListView;
-    private final SparseBooleanArray mYearsSelected = new SparseBooleanArray();
+    private Date mDateFrom;
+    private Date mDateTo;
+    private int mItemSelected = R.id.menu_current_year;
     private String mSort = SORT_ASCENDING;
     private boolean mMenuProviderRegistered = false;
 
@@ -97,13 +101,30 @@ public class IncomeVsExpensesListFragment
         super.onViewCreated(view, savedInstanceState);
         setupMenuProviders();
 
-        if (savedInstanceState != null && savedInstanceState.containsKey(KEY_BUNDLE_YEAR) &&
-                savedInstanceState.getIntArray(KEY_BUNDLE_YEAR) != null) {
-            for (int year : savedInstanceState.getIntArray(KEY_BUNDLE_YEAR)) {
-                mYearsSelected.put(year, true);
+        if (savedInstanceState != null) {
+            if (savedInstanceState.containsKey(KEY_BUNDLE_ITEM_SELECTED)) {
+                mItemSelected = savedInstanceState.getInt(KEY_BUNDLE_ITEM_SELECTED);
             }
-        } else {
-            mYearsSelected.put(Calendar.getInstance().get(Calendar.YEAR), true);
+            if (savedInstanceState.containsKey(KEY_BUNDLE_DATE_FROM)) {
+                String dateFromString = savedInstanceState.getString(KEY_BUNDLE_DATE_FROM);
+                if (!TextUtils.isEmpty(dateFromString)) {
+                    mDateFrom = new MmxDate(dateFromString).toDate();
+                }
+            }
+            if (savedInstanceState.containsKey(KEY_BUNDLE_DATE_TO)) {
+                String dateToString = savedInstanceState.getString(KEY_BUNDLE_DATE_TO);
+                if (!TextUtils.isEmpty(dateToString)) {
+                    mDateTo = new MmxDate(dateToString).toDate();
+                }
+            }
+        }
+
+        if (mDateFrom == null || mDateTo == null) {
+            com.money.manager.ex.core.DateRange defaultRange = ReportDateRangeSupport.resolveDateRange(requireContext(), R.id.menu_current_year);
+            if (defaultRange != null) {
+                mDateFrom = defaultRange.dateFrom;
+                mDateTo = defaultRange.dateTo;
+            }
         }
 
         initializeListView();
@@ -119,9 +140,7 @@ public class IncomeVsExpensesListFragment
         IncomeVsExpensesAdapter adapter = new IncomeVsExpensesAdapter(getActivity(), null);
         setListAdapter(adapter);
         setListShown(false);
-        // start loader
-        //getLoaderManager().restartLoader(ID_LOADER_YEARS, null, this);
-        getLoaderManager().initLoader(ID_LOADER_YEARS, null, this);
+        startLoader();
     }
 
     @Override
@@ -172,31 +191,12 @@ public class IncomeVsExpensesListFragment
 
     @Override
     public Loader<Cursor> onCreateLoader(int id, Bundle args) {
-        String selection = null;
-        Select query;
-
         switch (id) {
             case ID_LOADER_REPORT:
-                if (args != null && args.containsKey(KEY_BUNDLE_YEAR) && args.getString(KEY_BUNDLE_YEAR) != null) {
-                    selection = IncomeVsExpenseReportEntity.YEAR + " IN (" + args.getString(KEY_BUNDLE_YEAR) + ")";
-                    if (!TextUtils.isEmpty(selection)) {
-                        selection = "(" + selection + ")";
-                    }
-                }
-                // if don't have selection abort query
-                if (TextUtils.isEmpty(selection)) {
-                    selection = "1=2";
-                }
-                QueryReportIncomeVsExpenses report = new QueryReportIncomeVsExpenses(getActivity(), getAccountFilterSelection());
-                String reportSql = buildIncomeVsExpensesQuery(report, selection);
-                query = new Select().where(reportSql);
+                QueryReportIncomeVsExpenses report = new QueryReportIncomeVsExpenses(getActivity(), buildReportFilterClause());
+                String reportSql = buildIncomeVsExpensesQuery(report);
+                Select query = new Select().where(reportSql);
 
-                return new MmxCursorLoader(getActivity(), new SQLDataSet().getUri(), query);
-
-            case ID_LOADER_YEARS:
-                QueryMobileData mobileData = new QueryMobileData(getContext());
-                selection = "SELECT DISTINCT Year as Year FROM " + mobileData.getSource() + " ORDER BY Year DESC";
-                query = new Select().where(selection);
                 return new MmxCursorLoader(getActivity(), new SQLDataSet().getUri(), query);
         }
         return null;
@@ -249,19 +249,6 @@ public class IncomeVsExpensesListFragment
                     }, 1000);
                 }
                 break;
-
-            case ID_LOADER_YEARS:
-                if (data != null && data.moveToFirst()) {
-
-                    while (!data.isAfterLast()) {
-                        int year = data.getInt(data.getColumnIndexOrThrow(IncomeVsExpenseReportEntity.YEAR));
-                        if (!mYearsSelected.get(year, false)) {
-                            mYearsSelected.put(year, false);
-                        }
-                        data.moveToNext();
-                    }
-                    startLoader();
-                }
         }
     }
 
@@ -269,8 +256,17 @@ public class IncomeVsExpensesListFragment
 
     public void old_onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
         inflater.inflate(R.menu.menu_report_income_vs_expenses, menu);
+        inflater.inflate(R.menu.menu_period_picker, menu);
         if (menu.findItem(R.id.menu_account_filter) == null) {
             inflater.inflate(R.menu.menu_report_account_filter, menu);
+        }
+        MenuItem periodItem = menu.findItem(R.id.menu_period);
+        if (periodItem != null) {
+            periodItem.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
+        }
+        MenuItem selectedPeriod = menu.findItem(mItemSelected);
+        if (selectedPeriod != null) {
+            selectedPeriod.setChecked(true);
         }
         MenuItem selectedFilter = menu.findItem(getAccountFilterMode());
         if (selectedFilter != null) {
@@ -295,8 +291,8 @@ public class IncomeVsExpensesListFragment
             item.setChecked(true);
         } else if (item.getItemId() == R.id.menu_chart) {
             showChart();
-        } else if (item.getItemId() == R.id.menu_period) {
-            showDialogYears();
+        } else if (handlePeriodSelection(item)) {
+            return true;
         } else if (isAccountFilterMenuItem(item.getItemId())) {
             item.setChecked(true);
             saveAccountFilterMode(item.getItemId());
@@ -309,6 +305,32 @@ public class IncomeVsExpensesListFragment
         }
 
         return false;
+    }
+
+    private boolean handlePeriodSelection(MenuItem menuItem) {
+        int itemId = menuItem.getItemId();
+
+        if (itemId == R.id.menu_all_time) {
+            mDateFrom = null;
+            mDateTo = null;
+        } else if (itemId == R.id.menu_custom_dates) {
+            menuItem.setChecked(true);
+            mItemSelected = itemId;
+            showDialogCustomDates();
+            return true;
+        } else {
+            com.money.manager.ex.core.DateRange dateRange = ReportDateRangeSupport.resolveDateRange(requireContext(), itemId);
+            if (dateRange == null) {
+                return false;
+            }
+            mDateFrom = dateRange.dateFrom;
+            mDateTo = dateRange.dateTo;
+        }
+
+        menuItem.setChecked(true);
+        mItemSelected = itemId;
+        startLoader();
+        return true;
     }
 
     private boolean isAccountFilterMenuItem(int itemId) {
@@ -328,20 +350,31 @@ public class IncomeVsExpensesListFragment
     private String getAccountFilterSelection() {
         int mode = getAccountFilterMode();
         LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
-        List<Long> selectedIds = AccountFilterSupport.parseSelectedAccountIds(settings, PREF_FILTER_CUSTOM);
-        return AccountFilterSupport.getSelectionForAccountIdColumn(mode, selectedIds, "TX.ACCOUNTID");
+        return AccountFilterSupport.getSelectionForAccountIdColumn(
+                mode, settings, PREF_FILTER_CUSTOM, "TX.ACCOUNTID");
     }
 
     private void showAccountSelectionDialog() {
         LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
-        List<Long> selected = AccountFilterSupport.parseSelectedAccountIds(settings, PREF_FILTER_CUSTOM);
-        AccountFilterSupport.showAccountSelectionDialog(requireContext(), selected, selectedIds -> {
-            AccountFilterSupport.saveSelectedAccountIds(settings, PREF_FILTER_CUSTOM, selectedIds);
-            startLoader();
-        });
+        AccountFilterSupport.showAndPersistAccountSelectionDialog(
+                requireContext(), settings, PREF_FILTER_CUSTOM, this::startLoader);
     }
 
-    private String buildIncomeVsExpensesQuery(QueryReportIncomeVsExpenses report, String selection) {
+    private String buildReportFilterClause() {
+        String accountClause = getAccountFilterSelection();
+        String dateClause = ReportDateRangeSupport.buildWhereClause(mDateFrom, mDateTo, "date(TX.TransDate)");
+
+        if (TextUtils.isEmpty(accountClause)) {
+            return dateClause;
+        }
+        if (TextUtils.isEmpty(dateClause)) {
+            return accountClause;
+        }
+
+        return accountClause + " AND " + dateClause;
+    }
+
+    private String buildIncomeVsExpensesQuery(QueryReportIncomeVsExpenses report) {
         StringBuilder sql = new StringBuilder("SELECT ");
         String[] columns = report.getAllColumns();
         for (int i = 0; i < columns.length; i++) {
@@ -351,9 +384,6 @@ public class IncomeVsExpensesListFragment
             sql.append(columns[i]);
         }
         sql.append(" FROM (").append(report.getSource()).append(") T");
-        if (!TextUtils.isEmpty(selection)) {
-            sql.append(" WHERE ").append(selection);
-        }
         sql.append(" ORDER BY ")
                 .append(IncomeVsExpenseReportEntity.YEAR).append(" ").append(mSort)
                 .append(", ")
@@ -367,68 +397,21 @@ public class IncomeVsExpensesListFragment
     @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        ArrayList<Integer> years = new ArrayList();
-        for (int i = 0; i < mYearsSelected.size(); i++) {
-            if (mYearsSelected.get(mYearsSelected.keyAt(i))) {
-                years.add(mYearsSelected.keyAt(i));
-            }
+        if (mDateFrom != null) {
+            outState.putString(KEY_BUNDLE_DATE_FROM, new MmxDate(mDateFrom).toIsoDateString());
         }
-
-        // ArrayUtils.toPrimitive(years.toArray(new Integer[0]))
-        int[] yearsArray = Ints.toArray(years);
-        outState.putIntArray(KEY_BUNDLE_YEAR, yearsArray);
+        if (mDateTo != null) {
+            outState.putString(KEY_BUNDLE_DATE_TO, new MmxDate(mDateTo).toIsoDateString());
+        }
+        outState.putInt(KEY_BUNDLE_ITEM_SELECTED, mItemSelected);
     }
 
-    // Other
-
-    public void showDialogYears() {
-        // Assuming mYearsSelected is a SparseBooleanArray
-        ArrayList<String> years = new ArrayList<>();
-        List<Integer> selected = new ArrayList<>();
-
-        for (int i = 0; i < mYearsSelected.size(); i++) {
-            years.add(String.valueOf(mYearsSelected.keyAt(i)));
-
-            if (mYearsSelected.valueAt(i)) {
-                // SparseBooleanArray will be always in ASC order, so reversing the selection index
-                selected.add(mYearsSelected.size()-(i+1));
-            }
-        }
-
-        // SparseBooleanArray will be always in ASC order, so using sort option
-        Collections.sort(years, Collections.reverseOrder());
-
-        // Convert years to CharSequence array
-        final CharSequence[] items = years.toArray(new CharSequence[years.size()]);
-        // Convert selected to boolean array
-        final boolean[] checkedItems = new boolean[items.length];
-        for (int i = 0; i < items.length; i++) {
-            checkedItems[i] = selected.contains(i);
-        }
-
-        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-        builder.setMultiChoiceItems(items, checkedItems, new DialogInterface.OnMultiChoiceClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which, boolean isChecked) {
-                        checkedItems[which] = isChecked;
-                    }
-                })
-                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        // Reset all years to false
-                        for (int i = 0; i < mYearsSelected.size(); i++) {
-                            mYearsSelected.put(mYearsSelected.keyAt(i), false);
-                        }
-                        // Set selected years
-                        for (int i = 0; i < checkedItems.length; i++) {
-                            mYearsSelected.put(mYearsSelected.keyAt(checkedItems.length-(i+1)), checkedItems[i]);
-                        }
-                        startLoader();
-                    }
-                })
-                .setNegativeButton(android.R.string.cancel, null)
-                .show();
+    private void showDialogCustomDates() {
+        ReportDateRangeSupport.showCustomDateDialog(requireContext(), mDateFrom, mDateTo, (fromDate, toDate) -> {
+            mDateFrom = fromDate;
+            mDateTo = toDate;
+            startLoader();
+        });
     }
 
     // Private
@@ -514,19 +497,11 @@ public class IncomeVsExpensesListFragment
     }
 
     /**
-     * Start loader with arrays year
+     * Start loader with the current report date range.
      *
      */
     private void startLoader() {
-        Bundle bundle = new Bundle();
-        String years = "";
-        for (int i = 0; i < mYearsSelected.size(); i++) {
-            if (mYearsSelected.get(mYearsSelected.keyAt(i))) {
-                years += (!TextUtils.isEmpty(years) ? ", " : "") + mYearsSelected.keyAt(i);
-            }
-        }
-        bundle.putString(KEY_BUNDLE_YEAR, years);
-        getLoaderManager().restartLoader(ID_LOADER_REPORT, bundle, this);
+        getLoaderManager().restartLoader(ID_LOADER_REPORT, null, this);
     }
 
     /**

--- a/app/src/main/java/com/money/manager/ex/reports/IncomeVsExpensesListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/IncomeVsExpensesListFragment.java
@@ -53,6 +53,8 @@ import com.money.manager.ex.database.QueryReportIncomeVsExpenses;
 import com.money.manager.ex.database.SQLDataSet;
 import com.money.manager.ex.datalayer.Select;
 import com.money.manager.ex.search.SearchParameters;
+import com.money.manager.ex.settings.AppSettings;
+import com.money.manager.ex.settings.LookAndFeelSettings;
 import com.money.manager.ex.utils.MmxDate;
 import com.money.manager.ex.viewmodels.IncomeVsExpenseReportEntity;
 
@@ -82,6 +84,8 @@ public class IncomeVsExpensesListFragment
     private static final String SORT_ASCENDING = "ASC";
     private static final String SORT_DESCENDING = "DESC";
     private static final String KEY_BUNDLE_YEAR = "IncomeVsExpensesListFragment:Years";
+    private static final String PREF_FILTER_MODE = "IncomeVsExpensesFilterMode";
+    private static final String PREF_FILTER_CUSTOM = "IncomeVsExpensesFilterCustom";
 
     private View mFooterListView;
     private final SparseBooleanArray mYearsSelected = new SparseBooleanArray();
@@ -183,12 +187,11 @@ public class IncomeVsExpensesListFragment
                 if (TextUtils.isEmpty(selection)) {
                     selection = "1=2";
                 }
-                QueryReportIncomeVsExpenses report = new QueryReportIncomeVsExpenses(getActivity());
-                query = new Select(report.getAllColumns())
-                    .where(selection)
-                    .orderBy(IncomeVsExpenseReportEntity.YEAR + " " + mSort + ", " + IncomeVsExpenseReportEntity.Month + " " + mSort);
+                QueryReportIncomeVsExpenses report = new QueryReportIncomeVsExpenses(getActivity(), getAccountFilterSelection());
+                String reportSql = buildIncomeVsExpensesQuery(report, selection);
+                query = new Select().where(reportSql);
 
-                return new MmxCursorLoader(getActivity(), report.getUri(), query);
+                return new MmxCursorLoader(getActivity(), new SQLDataSet().getUri(), query);
 
             case ID_LOADER_YEARS:
                 QueryMobileData mobileData = new QueryMobileData(getContext());
@@ -266,6 +269,13 @@ public class IncomeVsExpensesListFragment
 
     public void old_onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
         inflater.inflate(R.menu.menu_report_income_vs_expenses, menu);
+        if (menu.findItem(R.id.menu_account_filter) == null) {
+            inflater.inflate(R.menu.menu_report_account_filter, menu);
+        }
+        MenuItem selectedFilter = menu.findItem(getAccountFilterMode());
+        if (selectedFilter != null) {
+            selectedFilter.setChecked(true);
+        }
         // fix menu char
         MenuItem itemChart = menu.findItem(R.id.menu_chart);
         if (itemChart != null) {
@@ -287,9 +297,69 @@ public class IncomeVsExpensesListFragment
             showChart();
         } else if (item.getItemId() == R.id.menu_period) {
             showDialogYears();
+        } else if (isAccountFilterMenuItem(item.getItemId())) {
+            item.setChecked(true);
+            saveAccountFilterMode(item.getItemId());
+            if (item.getItemId() == R.id.menu_account_filter_custom) {
+                showAccountSelectionDialog();
+            } else {
+                startLoader();
+            }
+            return true;
         }
 
         return false;
+    }
+
+    private boolean isAccountFilterMenuItem(int itemId) {
+        return AccountFilterSupport.isAccountFilterMenuItem(itemId);
+    }
+
+    private int getAccountFilterMode() {
+        LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
+        return AccountFilterSupport.getFilterMode(settings, PREF_FILTER_MODE, R.id.menu_account_filter_open);
+    }
+
+    private void saveAccountFilterMode(int mode) {
+        LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
+        AccountFilterSupport.saveFilterMode(settings, PREF_FILTER_MODE, mode);
+    }
+
+    private String getAccountFilterSelection() {
+        int mode = getAccountFilterMode();
+        LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
+        List<Long> selectedIds = AccountFilterSupport.parseSelectedAccountIds(settings, PREF_FILTER_CUSTOM);
+        return AccountFilterSupport.getSelectionForAccountIdColumn(mode, selectedIds, "TX.ACCOUNTID");
+    }
+
+    private void showAccountSelectionDialog() {
+        LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
+        List<Long> selected = AccountFilterSupport.parseSelectedAccountIds(settings, PREF_FILTER_CUSTOM);
+        AccountFilterSupport.showAccountSelectionDialog(requireContext(), selected, selectedIds -> {
+            AccountFilterSupport.saveSelectedAccountIds(settings, PREF_FILTER_CUSTOM, selectedIds);
+            startLoader();
+        });
+    }
+
+    private String buildIncomeVsExpensesQuery(QueryReportIncomeVsExpenses report, String selection) {
+        StringBuilder sql = new StringBuilder("SELECT ");
+        String[] columns = report.getAllColumns();
+        for (int i = 0; i < columns.length; i++) {
+            if (i > 0) {
+                sql.append(", ");
+            }
+            sql.append(columns[i]);
+        }
+        sql.append(" FROM (").append(report.getSource()).append(") T");
+        if (!TextUtils.isEmpty(selection)) {
+            sql.append(" WHERE ").append(selection);
+        }
+        sql.append(" ORDER BY ")
+                .append(IncomeVsExpenseReportEntity.YEAR).append(" ").append(mSort)
+                .append(", ")
+                .append(IncomeVsExpenseReportEntity.Month).append(" ").append(mSort);
+
+        return sql.toString();
     }
 
     //

--- a/app/src/main/java/com/money/manager/ex/reports/PayeeReportFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/PayeeReportFragment.java
@@ -219,26 +219,6 @@ public class PayeeReportFragment
         return super.old_onOptionsItemSelected(item);
     }
 
-    @Override
-    protected boolean isAccountFilterEnabled() {
-        return true;
-    }
-
-    @Override
-    protected boolean isPeriodPickerActionVisible() {
-        return true;
-    }
-
-    @Override
-    protected String getAccountFilterModePrefKey() {
-        return "PayeesFilterMode";
-    }
-
-    @Override
-    protected String getAccountFilterCustomPrefKey() {
-        return "PayeesFilterCustom";
-    }
-
     public void showChart() {
         PayeeReportAdapter adapter = (PayeeReportAdapter) getListAdapter();
         if (adapter == null) return;

--- a/app/src/main/java/com/money/manager/ex/reports/PayeeReportFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/PayeeReportFragment.java
@@ -177,6 +177,11 @@ public class PayeeReportFragment
                 QueryMobileData.ACCOUNTTYPE + "<>'"+ AccountTypes.SHARES.toString()  +"' AND " +
                 QueryMobileData.TOACCOUNTTYPE + "<>'"+ AccountTypes.SHARES.toString() +"'" ;
 
+        String accountFilterSelection = getAccountFilterSelection(QueryMobileData.ACCOUNTID);
+        if (!TextUtils.isEmpty(accountFilterSelection)) {
+            selection += " AND " + accountFilterSelection;
+        }
+
         if (!TextUtils.isEmpty(whereClause)) {
             selection += " AND " + whereClause;
         }
@@ -205,11 +210,33 @@ public class PayeeReportFragment
 
     @Override
     public boolean old_onOptionsItemSelected(@NonNull MenuItem item) {
-        if (item.getItemId() == R.id.menu_chart) {
+        int itemId = item.getItemId();
+        if (itemId == R.id.menu_chart) {
             showChart();
             return true;
         }
+
         return super.old_onOptionsItemSelected(item);
+    }
+
+    @Override
+    protected boolean isAccountFilterEnabled() {
+        return true;
+    }
+
+    @Override
+    protected boolean isPeriodPickerActionVisible() {
+        return true;
+    }
+
+    @Override
+    protected String getAccountFilterModePrefKey() {
+        return "PayeesFilterMode";
+    }
+
+    @Override
+    protected String getAccountFilterCustomPrefKey() {
+        return "PayeesFilterCustom";
     }
 
     public void showChart() {

--- a/app/src/main/java/com/money/manager/ex/reports/ReportDateRangeSupport.java
+++ b/app/src/main/java/com/money/manager/ex/reports/ReportDateRangeSupport.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2012-2026 The Android Money Manager Ex Project Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.money.manager.ex.reports;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.DatePicker;
+
+import com.money.manager.ex.core.DateRange;
+import com.money.manager.ex.core.InfoKeys;
+import com.money.manager.ex.R;
+import com.money.manager.ex.servicelayer.InfoService;
+import com.money.manager.ex.utils.MmxDate;
+import com.money.manager.ex.utils.MmxDateTimeUtils;
+
+import java.util.Date;
+import java.util.Locale;
+
+/**
+ * Shared date-range picker behavior for report screens.
+ */
+public final class ReportDateRangeSupport {
+
+    private ReportDateRangeSupport() {
+    }
+
+    public interface OnDateRangeSelectedListener {
+        void onDateRangeSelected(Date fromDate, Date toDate);
+    }
+
+    public static DateRange resolveDateRange(Context context, int itemId) {
+        MmxDate dateTime = MmxDate.newDate();
+
+        if (itemId == R.id.menu_current_month) {
+            return new DateRange(dateTime.firstDayOfMonth().toDate(), dateTime.lastDayOfMonth().toDate());
+        }
+        if (itemId == R.id.menu_last_month) {
+            MmxDate lastMonth = dateTime.minusMonths(1);
+            return new DateRange(lastMonth.firstDayOfMonth().toDate(), lastMonth.lastDayOfMonth().toDate());
+        }
+        if (itemId == R.id.menu_last_30_days) {
+            Date fromDate = MmxDate.newDate().minusDays(30).toDate();
+            Date toDate = MmxDate.newDate().toDate();
+            return new DateRange(fromDate, toDate);
+        }
+        if (itemId == R.id.menu_current_year) {
+            return new DateRange(dateTime.firstMonthOfYear().firstDayOfMonth().toDate(),
+                    dateTime.lastMonthOfYear().lastDayOfMonth().toDate());
+        }
+        if (itemId == R.id.menu_last_year) {
+            MmxDate lastYear = dateTime.minusYears(1);
+            return new DateRange(lastYear.firstMonthOfYear().firstDayOfMonth().toDate(),
+                    lastYear.lastMonthOfYear().lastDayOfMonth().toDate());
+        }
+        if (itemId == R.id.menu_current_fin_year || itemId == R.id.menu_last_fin_year) {
+            InfoService infoService = new InfoService(context);
+            int financialYearStartDay = Integer.parseInt(infoService.getInfoValue(InfoKeys.FINANCIAL_YEAR_START_DAY, "1"));
+            int financialYearStartMonth = Integer.parseInt(infoService.getInfoValue(InfoKeys.FINANCIAL_YEAR_START_MONTH, "1")) - 1;
+            if (financialYearStartMonth < 0) {
+                financialYearStartMonth = 0;
+            }
+
+            MmxDate fiscalStart = MmxDate.newDate();
+            fiscalStart.setDate(financialYearStartDay);
+            fiscalStart.setMonth(financialYearStartMonth);
+            if (fiscalStart.toDate().after(dateTime.toDate())) {
+                fiscalStart.minusYears(1);
+            }
+            if (itemId == R.id.menu_last_fin_year) {
+                fiscalStart.minusYears(1);
+            }
+            return new DateRange(fiscalStart.toDate(), fiscalStart.addYear(1).minusDays(1).toDate());
+        }
+
+        return null;
+    }
+
+    public static String buildWhereClause(Date fromDate, Date toDate, String dateColumn) {
+        if (fromDate == null || toDate == null) {
+            return null;
+        }
+
+        return dateColumn + " >= '" + new MmxDate(fromDate).toIsoDateString()
+                + "' AND " + dateColumn + " <= '" + new MmxDate(toDate).toIsoDateString() + "'";
+    }
+
+    public static void showCustomDateDialog(Context context, Date fromDate, Date toDate,
+            OnDateRangeSelectedListener listener) {
+        View dialogView = LayoutInflater.from(context).inflate(R.layout.dialog_choose_date_report, null);
+        DatePicker fromDatePicker = dialogView.findViewById(R.id.datePickerFromDate);
+        DatePicker toDatePicker = dialogView.findViewById(R.id.datePickerToDate);
+
+        Date startDate = fromDate != null ? fromDate : new MmxDate().today().toDate();
+        Date endDate = toDate != null ? toDate : new MmxDate().today().toDate();
+
+        MmxDateTimeUtils dateTimeUtils = new MmxDateTimeUtils(Locale.getDefault());
+        dateTimeUtils.setDatePicker(startDate, fromDatePicker);
+        dateTimeUtils.setDatePicker(endDate, toDatePicker);
+
+        new AlertDialog.Builder(context)
+                .setView(dialogView)
+                .setPositiveButton(android.R.string.ok, (dialog, which) ->
+                        listener.onDateRangeSelected(dateTimeUtils.from(fromDatePicker), dateTimeUtils.from(toDatePicker)))
+                .setNegativeButton(android.R.string.cancel, null)
+                .show();
+    }
+}

--- a/app/src/main/java/com/money/manager/ex/reports/ReportDateRangeSupport.java
+++ b/app/src/main/java/com/money/manager/ex/reports/ReportDateRangeSupport.java
@@ -45,50 +45,75 @@ public final class ReportDateRangeSupport {
     }
 
     public static DateRange resolveDateRange(Context context, int itemId) {
+        switch (itemId) {
+            case R.id.menu_current_month:
+                return resolveCurrentMonthRange();
+            case R.id.menu_last_month:
+                return resolveLastMonthRange();
+            case R.id.menu_last_30_days:
+                return resolveLast30DaysRange();
+            case R.id.menu_current_year:
+                return resolveCurrentYearRange();
+            case R.id.menu_last_year:
+                return resolveLastYearRange();
+            case R.id.menu_current_fin_year:
+                return resolveFinancialYearRange(context, false);
+            case R.id.menu_last_fin_year:
+                return resolveFinancialYearRange(context, true);
+            default:
+                return null;
+        }
+    }
+
+    private static DateRange resolveCurrentMonthRange() {
         MmxDate dateTime = MmxDate.newDate();
+        return new DateRange(dateTime.firstDayOfMonth().toDate(), dateTime.lastDayOfMonth().toDate());
+    }
 
-        if (itemId == R.id.menu_current_month) {
-            return new DateRange(dateTime.firstDayOfMonth().toDate(), dateTime.lastDayOfMonth().toDate());
-        }
-        if (itemId == R.id.menu_last_month) {
-            MmxDate lastMonth = dateTime.minusMonths(1);
-            return new DateRange(lastMonth.firstDayOfMonth().toDate(), lastMonth.lastDayOfMonth().toDate());
-        }
-        if (itemId == R.id.menu_last_30_days) {
-            Date fromDate = MmxDate.newDate().minusDays(30).toDate();
-            Date toDate = MmxDate.newDate().toDate();
-            return new DateRange(fromDate, toDate);
-        }
-        if (itemId == R.id.menu_current_year) {
-            return new DateRange(dateTime.firstMonthOfYear().firstDayOfMonth().toDate(),
-                    dateTime.lastMonthOfYear().lastDayOfMonth().toDate());
-        }
-        if (itemId == R.id.menu_last_year) {
-            MmxDate lastYear = dateTime.minusYears(1);
-            return new DateRange(lastYear.firstMonthOfYear().firstDayOfMonth().toDate(),
-                    lastYear.lastMonthOfYear().lastDayOfMonth().toDate());
-        }
-        if (itemId == R.id.menu_current_fin_year || itemId == R.id.menu_last_fin_year) {
-            InfoService infoService = new InfoService(context);
-            int financialYearStartDay = Integer.parseInt(infoService.getInfoValue(InfoKeys.FINANCIAL_YEAR_START_DAY, "1"));
-            int financialYearStartMonth = Integer.parseInt(infoService.getInfoValue(InfoKeys.FINANCIAL_YEAR_START_MONTH, "1")) - 1;
-            if (financialYearStartMonth < 0) {
-                financialYearStartMonth = 0;
-            }
+    private static DateRange resolveLastMonthRange() {
+        MmxDate lastMonth = MmxDate.newDate().minusMonths(1);
+        return new DateRange(lastMonth.firstDayOfMonth().toDate(), lastMonth.lastDayOfMonth().toDate());
+    }
 
-            MmxDate fiscalStart = MmxDate.newDate();
-            fiscalStart.setDate(financialYearStartDay);
-            fiscalStart.setMonth(financialYearStartMonth);
-            if (fiscalStart.toDate().after(dateTime.toDate())) {
-                fiscalStart.minusYears(1);
-            }
-            if (itemId == R.id.menu_last_fin_year) {
-                fiscalStart.minusYears(1);
-            }
-            return new DateRange(fiscalStart.toDate(), fiscalStart.addYear(1).minusDays(1).toDate());
+    private static DateRange resolveLast30DaysRange() {
+        Date fromDate = MmxDate.newDate().minusDays(30).toDate();
+        Date toDate = MmxDate.newDate().toDate();
+        return new DateRange(fromDate, toDate);
+    }
+
+    private static DateRange resolveCurrentYearRange() {
+        MmxDate dateTime = MmxDate.newDate();
+        return new DateRange(dateTime.firstMonthOfYear().firstDayOfMonth().toDate(),
+                dateTime.lastMonthOfYear().lastDayOfMonth().toDate());
+    }
+
+    private static DateRange resolveLastYearRange() {
+        MmxDate lastYear = MmxDate.newDate().minusYears(1);
+        return new DateRange(lastYear.firstMonthOfYear().firstDayOfMonth().toDate(),
+                lastYear.lastMonthOfYear().lastDayOfMonth().toDate());
+    }
+
+    private static DateRange resolveFinancialYearRange(Context context, boolean previousFinancialYear) {
+        InfoService infoService = new InfoService(context);
+        int financialYearStartDay = Integer.parseInt(infoService.getInfoValue(InfoKeys.FINANCIAL_YEAR_START_DAY, "1"));
+        int financialYearStartMonth = Integer.parseInt(infoService.getInfoValue(InfoKeys.FINANCIAL_YEAR_START_MONTH, "1")) - 1;
+        if (financialYearStartMonth < 0) {
+            financialYearStartMonth = 0;
         }
 
-        return null;
+        MmxDate fiscalStart = MmxDate.newDate();
+        MmxDate today = MmxDate.newDate();
+        fiscalStart.setDate(financialYearStartDay);
+        fiscalStart.setMonth(financialYearStartMonth);
+
+        if (fiscalStart.toDate().after(today.toDate())) {
+            fiscalStart.minusYears(1);
+        }
+        if (previousFinancialYear) {
+            fiscalStart.minusYears(1);
+        }
+
+        return new DateRange(fiscalStart.toDate(), fiscalStart.addYear(1).minusDays(1).toDate());
     }
 
     public static String buildWhereClause(Date fromDate, Date toDate, String dateColumn) {

--- a/app/src/main/java/com/money/manager/ex/reports/SummaryOfAccountsReportFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/SummaryOfAccountsReportFragment.java
@@ -526,17 +526,17 @@ public class SummaryOfAccountsReportFragment extends Fragment {
     }
 
     private boolean isAccountFilterMenuItem(int itemId) {
-        return itemId == R.id.menu_summary_accounts_all
-                || itemId == R.id.menu_summary_accounts_open
-                || itemId == R.id.menu_summary_accounts_favorite
-                || itemId == R.id.menu_summary_accounts_custom;
+        return itemId == R.id.menu_account_filter_all
+            || itemId == R.id.menu_account_filter_open
+            || itemId == R.id.menu_account_filter_favorite
+            || itemId == R.id.menu_account_filter_custom;
     }
 
     private void handleAccountFilterItemSelected(int itemId, @NonNull MenuItem item) {
         item.setChecked(true);
         saveFilterMode(itemId);
 
-        if (itemId == R.id.menu_summary_accounts_custom) {
+        if (itemId == R.id.menu_account_filter_custom) {
             showAccountSelectionDialog();
             return;
         }
@@ -687,11 +687,11 @@ public class SummaryOfAccountsReportFragment extends Fragment {
 
     private int getFilterMode() {
         LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
-        String storedValue = settings.get(PREF_FILTER_MODE, Integer.toString(R.id.menu_summary_accounts_open));
+        String storedValue = settings.get(PREF_FILTER_MODE, Integer.toString(R.id.menu_account_filter_open));
         try {
             return Integer.parseInt(storedValue);
         } catch (Exception e) {
-            return R.id.menu_summary_accounts_open;
+            return R.id.menu_account_filter_open;
         }
     }
 
@@ -726,16 +726,16 @@ public class SummaryOfAccountsReportFragment extends Fragment {
     }
 
     private String getAccountWhereClause(AccountFilter filter) {
-        if (filter.mode == R.id.menu_summary_accounts_all) {
+        if (filter.mode == R.id.menu_account_filter_all) {
             return "";
         }
-        if (filter.mode == R.id.menu_summary_accounts_open) {
+        if (filter.mode == R.id.menu_account_filter_open) {
             return "WHERE lower(a.STATUS) = 'open'";
         }
-        if (filter.mode == R.id.menu_summary_accounts_favorite) {
+        if (filter.mode == R.id.menu_account_filter_favorite) {
             return "WHERE lower(a.FAVORITEACCT) = 'true'";
         }
-        if (filter.mode == R.id.menu_summary_accounts_custom) {
+        if (filter.mode == R.id.menu_account_filter_custom) {
             if (filter.customAccountIds.isEmpty()) {
                 return "WHERE 1=2";
             }
@@ -778,7 +778,7 @@ public class SummaryOfAccountsReportFragment extends Fragment {
         }
 
         AlertDialog.Builder builder = new AlertDialog.Builder(requireContext());
-        builder.setTitle(R.string.menu_cashflow_custom);
+        builder.setTitle(R.string.menu_account_filter_custom);
         builder.setMultiChoiceItems(accountNames.toArray(new CharSequence[0]), checkedItems,
                 (dialog, which, isChecked) -> checkedItems[which] = isChecked);
         builder.setPositiveButton(android.R.string.ok, (dialog, which) -> {

--- a/app/src/main/java/com/money/manager/ex/reports/SummaryOfAccountsReportFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/SummaryOfAccountsReportFragment.java
@@ -45,7 +45,6 @@ import com.money.manager.ex.account.AccountTypes;
 import com.money.manager.ex.core.InfoKeys;
 import com.money.manager.ex.core.UIHelper;
 import com.money.manager.ex.currency.CurrencyService;
-import com.money.manager.ex.database.QueryAccountBills;
 import com.money.manager.ex.database.SQLDataSet;
 import com.money.manager.ex.servicelayer.InfoService;
 import com.money.manager.ex.settings.AppSettings;
@@ -146,11 +145,12 @@ public class SummaryOfAccountsReportFragment extends Fragment {
     }
 
     private ReportTableModel buildModel() {
-        AccountFilter accountFilter = getAccountFilter();
+        int filterMode = getFilterMode();
+        List<Long> selectedAccountIds = getSelectedAccountIds();
         int groupMode = getGroupMode();
         BuildState state = new BuildState();
 
-        loadAccounts(state, getAccountWhereClause(accountFilter));
+        loadAccounts(state, getAccountWhereClause(filterMode, selectedAccountIds));
         loadTransactions(state);
 
         normalizeDateBounds(state);
@@ -526,10 +526,7 @@ public class SummaryOfAccountsReportFragment extends Fragment {
     }
 
     private boolean isAccountFilterMenuItem(int itemId) {
-        return itemId == R.id.menu_account_filter_all
-            || itemId == R.id.menu_account_filter_open
-            || itemId == R.id.menu_account_filter_favorite
-            || itemId == R.id.menu_account_filter_custom;
+        return AccountFilterSupport.isAccountFilterMenuItem(itemId);
     }
 
     private void handleAccountFilterItemSelected(int itemId, @NonNull MenuItem item) {
@@ -687,17 +684,12 @@ public class SummaryOfAccountsReportFragment extends Fragment {
 
     private int getFilterMode() {
         LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
-        String storedValue = settings.get(PREF_FILTER_MODE, Integer.toString(R.id.menu_account_filter_open));
-        try {
-            return Integer.parseInt(storedValue);
-        } catch (Exception e) {
-            return R.id.menu_account_filter_open;
-        }
+        return AccountFilterSupport.getFilterMode(settings, PREF_FILTER_MODE, R.id.menu_account_filter_open);
     }
 
     private void saveFilterMode(int mode) {
         LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
-        settings.set(PREF_FILTER_MODE, Integer.toString(mode));
+        AccountFilterSupport.saveFilterMode(settings, PREF_FILTER_MODE, mode);
     }
 
     private int getGroupMode() {
@@ -719,118 +711,26 @@ public class SummaryOfAccountsReportFragment extends Fragment {
         settings.set(PREF_GROUP_MODE, Integer.toString(mode));
     }
 
-    private AccountFilter getAccountFilter() {
-        int mode = getFilterMode();
-        List<Long> customAccountIds = parseSelectedAccountIds();
-        return new AccountFilter(mode, customAccountIds);
+    private List<Long> getSelectedAccountIds() {
+        LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
+        return AccountFilterSupport.parseSelectedAccountIds(settings, PREF_FILTER_CUSTOM);
     }
 
-    private String getAccountWhereClause(AccountFilter filter) {
-        if (filter.mode == R.id.menu_account_filter_all) {
+    private String getAccountWhereClause(int mode, List<Long> selectedAccountIds) {
+        String selection = AccountFilterSupport.getSelectionForAccountIdColumn(mode, selectedAccountIds, "a.ACCOUNTID");
+        if (TextUtils.isEmpty(selection)) {
             return "";
         }
-        if (filter.mode == R.id.menu_account_filter_open) {
-            return "WHERE lower(a.STATUS) = 'open'";
-        }
-        if (filter.mode == R.id.menu_account_filter_favorite) {
-            return "WHERE lower(a.FAVORITEACCT) = 'true'";
-        }
-        if (filter.mode == R.id.menu_account_filter_custom) {
-            if (filter.customAccountIds.isEmpty()) {
-                return "WHERE 1=2";
-            }
-            return "WHERE a.ACCOUNTID IN (" + joinIds(filter.customAccountIds) + ")";
-        }
-        return "";
+        return "WHERE " + selection;
     }
 
     private void showAccountSelectionDialog() {
-        ArrayList<Long> selected = new ArrayList<>(parseSelectedAccountIds());
-
-        QueryAccountBills queryAccountBills = new QueryAccountBills(requireContext());
-        Cursor cursor = requireContext().getContentResolver().query(
-                queryAccountBills.getUri(),
-                null,
-                null,
-                null,
-                QueryAccountBills.ACCOUNTTYPE + ", upper(" + QueryAccountBills.ACCOUNTNAME + ")");
-
-        if (cursor == null) {
-            return;
-        }
-
-        final ArrayList<Long> accountIds = new ArrayList<>();
-        final ArrayList<String> accountNames = new ArrayList<>();
-        try {
-            while (cursor.moveToNext()) {
-                long accountId = cursor.getLong(cursor.getColumnIndexOrThrow(QueryAccountBills.ACCOUNTID));
-                String accountName = cursor.getString(cursor.getColumnIndexOrThrow(QueryAccountBills.ACCOUNTNAME));
-                accountIds.add(accountId);
-                accountNames.add(accountName);
-            }
-        } finally {
-            cursor.close();
-        }
-
-        final boolean[] checkedItems = new boolean[accountIds.size()];
-        for (int i = 0; i < accountIds.size(); i++) {
-            checkedItems[i] = selected.contains(accountIds.get(i));
-        }
-
-        AlertDialog.Builder builder = new AlertDialog.Builder(requireContext());
-        builder.setTitle(R.string.menu_account_filter_custom);
-        builder.setMultiChoiceItems(accountNames.toArray(new CharSequence[0]), checkedItems,
-                (dialog, which, isChecked) -> checkedItems[which] = isChecked);
-        builder.setPositiveButton(android.R.string.ok, (dialog, which) -> {
-            ArrayList<Long> selectedIds = new ArrayList<>();
-            for (int i = 0; i < accountIds.size(); i++) {
-                if (checkedItems[i]) {
-                    selectedIds.add(accountIds.get(i));
-                }
-            }
-            saveSelectedAccountIds(selectedIds);
+        LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
+        List<Long> selected = AccountFilterSupport.parseSelectedAccountIds(settings, PREF_FILTER_CUSTOM);
+        AccountFilterSupport.showAccountSelectionDialog(requireContext(), selected, selectedIds -> {
+            AccountFilterSupport.saveSelectedAccountIds(settings, PREF_FILTER_CUSTOM, selectedIds);
             loadReportAsync();
         });
-        builder.setNegativeButton(android.R.string.cancel, null);
-        builder.show();
-    }
-
-    private ArrayList<Long> parseSelectedAccountIds() {
-        LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
-        String raw = settings.get(PREF_FILTER_CUSTOM, "");
-        ArrayList<Long> result = new ArrayList<>();
-        if (raw.trim().isEmpty()) {
-            return result;
-        }
-
-        String[] ids = raw.split(",");
-        for (String id : ids) {
-            if (id.trim().isEmpty()) {
-                continue;
-            }
-            try {
-                result.add(Long.parseLong(id.trim()));
-            } catch (Exception e) {
-                Timber.w(e, "Invalid account id in filter: %s", id);
-            }
-        }
-        return result;
-    }
-
-    private void saveSelectedAccountIds(List<Long> ids) {
-        LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
-        settings.set(PREF_FILTER_CUSTOM, joinIds(ids));
-    }
-
-    private String joinIds(List<Long> ids) {
-        StringBuilder builder = new StringBuilder();
-        for (int i = 0; i < ids.size(); i++) {
-            if (i > 0) {
-                builder.append(',');
-            }
-            builder.append(ids.get(i));
-        }
-        return builder.toString();
     }
 
     private LocalDate toLocalDate(@Nullable Date date) {
@@ -971,16 +871,6 @@ public class SummaryOfAccountsReportFragment extends Fragment {
             this.orderedTypes = orderedTypes;
             this.typeLabels = typeLabels;
             this.rows = rows;
-        }
-    }
-
-    private static class AccountFilter {
-        private final int mode;
-        private final List<Long> customAccountIds;
-
-        AccountFilter(int mode, List<Long> customAccountIds) {
-            this.mode = mode;
-            this.customAccountIds = customAccountIds;
         }
     }
 

--- a/app/src/main/java/com/money/manager/ex/reports/SummaryOfAccountsReportFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/SummaryOfAccountsReportFragment.java
@@ -16,7 +16,6 @@
  */
 package com.money.manager.ex.reports;
 
-import android.app.AlertDialog;
 import android.content.Intent;
 import android.database.Cursor;
 import android.os.Bundle;
@@ -28,7 +27,6 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.DatePicker;
 import android.widget.TableLayout;
 import android.widget.TableRow;
 import android.widget.TextView;
@@ -42,15 +40,12 @@ import androidx.lifecycle.Lifecycle;
 
 import com.money.manager.ex.R;
 import com.money.manager.ex.account.AccountTypes;
-import com.money.manager.ex.core.InfoKeys;
 import com.money.manager.ex.core.UIHelper;
 import com.money.manager.ex.currency.CurrencyService;
 import com.money.manager.ex.database.SQLDataSet;
-import com.money.manager.ex.servicelayer.InfoService;
 import com.money.manager.ex.settings.AppSettings;
 import com.money.manager.ex.settings.LookAndFeelSettings;
 import com.money.manager.ex.utils.MmxDate;
-import com.money.manager.ex.utils.MmxDateTimeUtils;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -146,11 +141,13 @@ public class SummaryOfAccountsReportFragment extends Fragment {
 
     private ReportTableModel buildModel() {
         int filterMode = getFilterMode();
-        List<Long> selectedAccountIds = getSelectedAccountIds();
         int groupMode = getGroupMode();
         BuildState state = new BuildState();
 
-        loadAccounts(state, getAccountWhereClause(filterMode, selectedAccountIds));
+        LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
+        String accountWhere = AccountFilterSupport.getWhereClauseForAccountIdColumn(
+            filterMode, settings, PREF_FILTER_CUSTOM, "a.ACCOUNTID");
+        loadAccounts(state, accountWhere);
         loadTransactions(state);
 
         normalizeDateBounds(state);
@@ -562,44 +559,9 @@ public class SummaryOfAccountsReportFragment extends Fragment {
     }
 
     private boolean handlePeriodSelection(@NonNull MenuItem menuItem) {
-        MmxDate dateTime = MmxDate.newDate();
         int itemId = menuItem.getItemId();
 
-        if (itemId == R.id.menu_current_month) {
-            mDateFrom = dateTime.firstDayOfMonth().toDate();
-            mDateTo = dateTime.lastDayOfMonth().toDate();
-        } else if (itemId == R.id.menu_last_month) {
-            mDateFrom = dateTime.minusMonths(1).firstDayOfMonth().toDate();
-            mDateTo = dateTime.lastDayOfMonth().toDate();
-        } else if (itemId == R.id.menu_last_30_days) {
-            mDateTo = dateTime.toDate();
-            mDateFrom = dateTime.minusDays(30).toDate();
-        } else if (itemId == R.id.menu_current_year) {
-            mDateFrom = dateTime.firstMonthOfYear().firstDayOfMonth().toDate();
-            mDateTo = dateTime.lastMonthOfYear().lastDayOfMonth().toDate();
-        } else if (itemId == R.id.menu_last_year) {
-            mDateFrom = dateTime.minusYears(1).firstMonthOfYear().firstDayOfMonth().toDate();
-            mDateTo = dateTime.lastMonthOfYear().lastDayOfMonth().toDate();
-        } else if (itemId == R.id.menu_current_fin_year || itemId == R.id.menu_last_fin_year) {
-            InfoService infoService = new InfoService(requireContext());
-            int financialYearStartDay = Integer.parseInt(infoService.getInfoValue(InfoKeys.FINANCIAL_YEAR_START_DAY, "1"));
-            int financialYearStartMonth = Integer.parseInt(infoService.getInfoValue(InfoKeys.FINANCIAL_YEAR_START_MONTH, "1")) - 1;
-            if (financialYearStartMonth < 0) {
-                financialYearStartMonth = 0;
-            }
-
-            MmxDate fiscalStart = MmxDate.newDate();
-            fiscalStart.setDate(financialYearStartDay);
-            fiscalStart.setMonth(financialYearStartMonth);
-            if (fiscalStart.toDate().after(dateTime.toDate())) {
-                fiscalStart.minusYears(1);
-            }
-            if (itemId == R.id.menu_last_fin_year) {
-                fiscalStart.minusYears(1);
-            }
-            mDateFrom = fiscalStart.toDate();
-            mDateTo = fiscalStart.addYear(1).minusDays(1).toDate();
-        } else if (itemId == R.id.menu_all_time) {
+        if (itemId == R.id.menu_all_time) {
             mDateFrom = null;
             mDateTo = null;
         } else if (itemId == R.id.menu_custom_dates) {
@@ -608,7 +570,12 @@ public class SummaryOfAccountsReportFragment extends Fragment {
             showDialogCustomDates();
             return true;
         } else {
-            return false;
+            com.money.manager.ex.core.DateRange dateRange = ReportDateRangeSupport.resolveDateRange(requireContext(), itemId);
+            if (dateRange == null) {
+                return false;
+            }
+            mDateFrom = dateRange.dateFrom;
+            mDateTo = dateRange.dateTo;
         }
 
         mItemSelected = itemId;
@@ -655,31 +622,11 @@ public class SummaryOfAccountsReportFragment extends Fragment {
     }
 
     private void showDialogCustomDates() {
-        View dialogView = LayoutInflater.from(getActivity()).inflate(R.layout.dialog_choose_date_report, null);
-        DatePicker fromDatePicker = dialogView.findViewById(R.id.datePickerFromDate);
-        DatePicker toDatePicker = dialogView.findViewById(R.id.datePickerToDate);
-
-        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-        builder.setView(dialogView)
-                .setPositiveButton(android.R.string.ok, (dialog, which) -> {
-                    MmxDateTimeUtils dateTimeUtils = new MmxDateTimeUtils(Locale.getDefault());
-                    mDateFrom = dateTimeUtils.from(fromDatePicker);
-                    mDateTo = dateTimeUtils.from(toDatePicker);
-                    loadReportAsync();
-                })
-                .setNegativeButton(android.R.string.cancel, null)
-                .show();
-
-        if (mDateFrom == null) {
-            mDateFrom = new MmxDate().today().toDate();
-        }
-        if (mDateTo == null) {
-            mDateTo = new MmxDate().today().toDate();
-        }
-
-        MmxDateTimeUtils dateTimeUtils = new MmxDateTimeUtils(Locale.getDefault());
-        dateTimeUtils.setDatePicker(mDateFrom, fromDatePicker);
-        dateTimeUtils.setDatePicker(mDateTo, toDatePicker);
+        ReportDateRangeSupport.showCustomDateDialog(requireContext(), mDateFrom, mDateTo, (fromDate, toDate) -> {
+            mDateFrom = fromDate;
+            mDateTo = toDate;
+            loadReportAsync();
+        });
     }
 
     private int getFilterMode() {
@@ -711,26 +658,10 @@ public class SummaryOfAccountsReportFragment extends Fragment {
         settings.set(PREF_GROUP_MODE, Integer.toString(mode));
     }
 
-    private List<Long> getSelectedAccountIds() {
-        LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
-        return AccountFilterSupport.parseSelectedAccountIds(settings, PREF_FILTER_CUSTOM);
-    }
-
-    private String getAccountWhereClause(int mode, List<Long> selectedAccountIds) {
-        String selection = AccountFilterSupport.getSelectionForAccountIdColumn(mode, selectedAccountIds, "a.ACCOUNTID");
-        if (TextUtils.isEmpty(selection)) {
-            return "";
-        }
-        return "WHERE " + selection;
-    }
-
     private void showAccountSelectionDialog() {
         LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
-        List<Long> selected = AccountFilterSupport.parseSelectedAccountIds(settings, PREF_FILTER_CUSTOM);
-        AccountFilterSupport.showAccountSelectionDialog(requireContext(), selected, selectedIds -> {
-            AccountFilterSupport.saveSelectedAccountIds(settings, PREF_FILTER_CUSTOM, selectedIds);
-            loadReportAsync();
-        });
+        AccountFilterSupport.showAndPersistAccountSelectionDialog(
+                requireContext(), settings, PREF_FILTER_CUSTOM, this::loadReportAsync);
     }
 
     private LocalDate toLocalDate(@Nullable Date date) {

--- a/app/src/main/java/com/money/manager/ex/reports/cashflow/CashFlowReportListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/cashflow/CashFlowReportListFragment.java
@@ -273,18 +273,18 @@ public class CashFlowReportListFragment
 
     private void getTotalAmountAndAccounts() {
         LookAndFeelSettings settings = new AppSettings(getContext()).getLookAndFeelSettings();
-        int accountFilter = settings.get(R.menu.menu_cashflow, R.id.menu_cashflow_open);
+        int accountFilter = settings.get(R.menu.menu_cashflow, R.id.menu_account_filter_open);
         String accountCustomFilters = "";
-        if ( accountFilter == R.id.menu_cashflow_custom ) {
+        if ( accountFilter == R.id.menu_account_filter_custom ) {
             accountCustomFilters = settings.get("AccountFilterCustom", "");
         }
         // compose whereClause
         String where = "";
-        if (accountFilter == R.id.menu_cashflow_open) {
+        if (accountFilter == R.id.menu_account_filter_open) {
             where += "LOWER(" + QueryAccountBills.STATUS + ") = 'open'";
-        } else if (accountFilter == R.id.menu_cashflow_favorite) {
+        } else if (accountFilter == R.id.menu_account_filter_favorite) {
             where += "LOWER(" + QueryAccountBills.FAVORITEACCT + ") = 'true'";
-        } else if (accountFilter == R.id.menu_cashflow_custom) {
+        } else if (accountFilter == R.id.menu_account_filter_custom) {
             where += QueryAccountBills.ACCOUNTID + " IN ( " + accountCustomFilters + " )";
         }
 
@@ -527,7 +527,7 @@ public class CashFlowReportListFragment
             menu.findItem(R.id.menu_cashflow_24_months).setChecked(true);
         }
 
-        int accountFilter = settings.get(R.menu.menu_cashflow, R.id.menu_cashflow_open);
+        int accountFilter = settings.get(R.menu.menu_cashflow, R.id.menu_account_filter_open);
         if ( menu.findItem(accountFilter) != null ) {
             menu.findItem(accountFilter).setChecked(true);
         }
@@ -537,7 +537,7 @@ public class CashFlowReportListFragment
     public boolean old_onOptionsItemSelected(@NonNull MenuItem item) {
         // handle accounts filter
         LookAndFeelSettings settings = new AppSettings(getContext()).getLookAndFeelSettings();
-//        int accountFilter = settings.get(R.menu.menu_cashflow, R.id.menu_cashflow_open);
+//        int accountFilter = settings.get(R.menu.menu_cashflow, R.id.menu_account_filter_open);
         int itemId = item.getItemId();
         if (itemId == R.id.menu_cashflow_24_months) {
             monthInAdvance = (item.isChecked()) ? 12 : 24;
@@ -545,10 +545,10 @@ public class CashFlowReportListFragment
             settings.set(R.id.menu_cashflow_24_months, item.isChecked());
             getActivity().recreate();
             return true;
-        } else if (itemId == R.id.menu_cashflow_all || itemId == R.id.menu_cashflow_open || itemId == R.id.menu_cashflow_favorite || itemId == R.id.menu_cashflow_custom) {
+        } else if (itemId == R.id.menu_account_filter_all || itemId == R.id.menu_account_filter_open || itemId == R.id.menu_account_filter_favorite || itemId == R.id.menu_account_filter_custom) {
             item.setChecked(true);
             settings.set(R.menu.menu_cashflow, item.getItemId());
-            if (item.getItemId() == R.id.menu_cashflow_custom) {
+            if (item.getItemId() == R.id.menu_account_filter_custom) {
                 // call popup
                 String where = "";
                 if (settings.getViewOpenAccounts()) {

--- a/app/src/main/java/com/money/manager/ex/reports/cashflow/CashFlowReportListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/cashflow/CashFlowReportListFragment.java
@@ -38,7 +38,6 @@ import com.github.mikephil.charting.components.LimitLine;
 import com.github.mikephil.charting.data.Entry;
 
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
 
 import com.github.mikephil.charting.charts.LineChart;
 import com.github.mikephil.charting.data.LineData;
@@ -54,6 +53,7 @@ import com.money.manager.ex.core.UIHelper;
 import com.money.manager.ex.currency.CurrencyService;
 import com.money.manager.ex.database.QueryAccountBills;
 import com.money.manager.ex.database.QueryBillDeposits;
+import com.money.manager.ex.reports.AccountFilterSupport;
 import com.money.manager.ex.domainmodel.RecurringTransaction;
 import com.money.manager.ex.servicelayer.InfoService;
 import com.money.manager.ex.servicelayer.RecurringTransactionService;
@@ -88,6 +88,8 @@ public class CashFlowReportListFragment
         extends BaseListFragment {
 
 //    private static final int ID_LOADER_REPORT = 1;
+    private static final String PREF_FILTER_MODE = "CashFlowFilterMode";
+    private static final String PREF_FILTER_CUSTOM = "CashFlowFilterCustom";
     private double totalAmount = 0;
     private static final String ID = "_id";
     private static final String BALANCE = "BALANCE";
@@ -273,20 +275,13 @@ public class CashFlowReportListFragment
 
     private void getTotalAmountAndAccounts() {
         LookAndFeelSettings settings = new AppSettings(getContext()).getLookAndFeelSettings();
-        int accountFilter = settings.get(R.menu.menu_cashflow, R.id.menu_account_filter_open);
-        String accountCustomFilters = "";
-        if ( accountFilter == R.id.menu_account_filter_custom ) {
-            accountCustomFilters = settings.get("AccountFilterCustom", "");
-        }
+        int accountFilter = AccountFilterSupport.getFilterMode(settings, PREF_FILTER_MODE, R.id.menu_account_filter_open);
+        List<Long> selectedCustomAccounts = AccountFilterSupport.parseSelectedAccountIds(settings, PREF_FILTER_CUSTOM);
         // compose whereClause
-        String where = "";
-        if (accountFilter == R.id.menu_account_filter_open) {
-            where += "LOWER(" + QueryAccountBills.STATUS + ") = 'open'";
-        } else if (accountFilter == R.id.menu_account_filter_favorite) {
-            where += "LOWER(" + QueryAccountBills.FAVORITEACCT + ") = 'true'";
-        } else if (accountFilter == R.id.menu_account_filter_custom) {
-            where += QueryAccountBills.ACCOUNTID + " IN ( " + accountCustomFilters + " )";
-        }
+        String where = AccountFilterSupport.getSelectionForAccountIdColumn(
+                accountFilter,
+                selectedCustomAccounts,
+                QueryAccountBills.ACCOUNTID);
 
         QueryAccountBills queryAccountBills = new QueryAccountBills(getActivity());
         selectedAccounts = new ArrayList<>();
@@ -527,7 +522,7 @@ public class CashFlowReportListFragment
             menu.findItem(R.id.menu_cashflow_24_months).setChecked(true);
         }
 
-        int accountFilter = settings.get(R.menu.menu_cashflow, R.id.menu_account_filter_open);
+        int accountFilter = AccountFilterSupport.getFilterMode(settings, PREF_FILTER_MODE, R.id.menu_account_filter_open);
         if ( menu.findItem(accountFilter) != null ) {
             menu.findItem(accountFilter).setChecked(true);
         }
@@ -537,7 +532,6 @@ public class CashFlowReportListFragment
     public boolean old_onOptionsItemSelected(@NonNull MenuItem item) {
         // handle accounts filter
         LookAndFeelSettings settings = new AppSettings(getContext()).getLookAndFeelSettings();
-//        int accountFilter = settings.get(R.menu.menu_cashflow, R.id.menu_account_filter_open);
         int itemId = item.getItemId();
         if (itemId == R.id.menu_cashflow_24_months) {
             monthInAdvance = (item.isChecked()) ? 12 : 24;
@@ -545,63 +539,15 @@ public class CashFlowReportListFragment
             settings.set(R.id.menu_cashflow_24_months, item.isChecked());
             getActivity().recreate();
             return true;
-        } else if (itemId == R.id.menu_account_filter_all || itemId == R.id.menu_account_filter_open || itemId == R.id.menu_account_filter_favorite || itemId == R.id.menu_account_filter_custom) {
+        } else if (AccountFilterSupport.isAccountFilterMenuItem(itemId)) {
             item.setChecked(true);
-            settings.set(R.menu.menu_cashflow, item.getItemId());
+            AccountFilterSupport.saveFilterMode(settings, PREF_FILTER_MODE, item.getItemId());
             if (item.getItemId() == R.id.menu_account_filter_custom) {
-                // call popup
-                String where = "";
-                if (settings.getViewOpenAccounts()) {
-                    where = "LOWER(" + QueryAccountBills.STATUS + ")='open'";
-                }
-                selectedAccounts = new ArrayList<>();
-                String[] accountList = settings.get("AccountFilterCustom", "").split(",");
-                for (String x : accountList) {
-                    if (!x.isEmpty())
-                        try {
-                            selectedAccounts.add(Long.valueOf(x));
-                        } catch (Exception e) {
-                        }
-                }
-                QueryAccountBills queryAccountBills = new QueryAccountBills(getActivity());
-                Cursor c = getContext().getContentResolver().query(queryAccountBills.getUri(),
-                        null,
-                        where,
-                        null,
-                        QueryAccountBills.ACCOUNTTYPE + ", upper(" + QueryAccountBills.ACCOUNTNAME + ")");
-                if (c == null) return false;
-                MatrixCursor matrixCursor = new MatrixCursor(new String[]{"_id", QueryAccountBills.ACCOUNTNAME, "CHECKED"});
-                while (c.moveToNext()) {
-                    long id = c.getLong(c.getColumnIndexOrThrow(QueryAccountBills.ACCOUNTID));
-                    matrixCursor.newRow()
-                            .add("_id", id)
-                            .add(QueryAccountBills.ACCOUNTNAME, c.getString(c.getColumnIndexOrThrow(QueryAccountBills.ACCOUNTNAME)))
-                            .add("CHECKED", (selectedAccounts.contains(id) ? 1 : 0));
-                }
-                c.close();
-                AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
-                builder.setTitle("Select Accounts");
-                builder.setCancelable(false);
-                builder.setMultiChoiceItems(matrixCursor, "CHECKED", QueryAccountBills.ACCOUNTNAME,
-                        (dialog, which, isChecked) -> {
-                            matrixCursor.moveToPosition(which);
-                            long id = matrixCursor.getLong(matrixCursor.getColumnIndexOrThrow("_id"));
-                            if (!isChecked) {
-//                                    if ( selectedAccounts.contains(id) ) {
-                                selectedAccounts.remove(id);
-//                                    }
-                            } else {
-                                if (!selectedAccounts.contains(id)) {
-                                    selectedAccounts.add(id);
-                                }
-                            }
-                        });
-                builder.setPositiveButton(android.R.string.ok, (dialog, which) -> {
-                    settings.set("AccountFilterCustom", selectedAccounts.toString().replace("[", "").replace("]", "").replace(" ", ""));
+                List<Long> selected = AccountFilterSupport.parseSelectedAccountIds(settings, PREF_FILTER_CUSTOM);
+                AccountFilterSupport.showAccountSelectionDialog(requireContext(), selected, selectedIds -> {
+                    AccountFilterSupport.saveSelectedAccountIds(settings, PREF_FILTER_CUSTOM, selectedIds);
                     getActivity().recreate();
                 });
-                builder.show();
-                settings.set("AccountFilterCustom", "");
                 return true;
             }
             getActivity().recreate();

--- a/app/src/main/java/com/money/manager/ex/reports/cashflow/CashFlowReportListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/cashflow/CashFlowReportListFragment.java
@@ -276,12 +276,12 @@ public class CashFlowReportListFragment
     private void getTotalAmountAndAccounts() {
         LookAndFeelSettings settings = new AppSettings(getContext()).getLookAndFeelSettings();
         int accountFilter = AccountFilterSupport.getFilterMode(settings, PREF_FILTER_MODE, R.id.menu_account_filter_open);
-        List<Long> selectedCustomAccounts = AccountFilterSupport.parseSelectedAccountIds(settings, PREF_FILTER_CUSTOM);
         // compose whereClause
         String where = AccountFilterSupport.getSelectionForAccountIdColumn(
-                accountFilter,
-                selectedCustomAccounts,
-                QueryAccountBills.ACCOUNTID);
+            accountFilter,
+            settings,
+            PREF_FILTER_CUSTOM,
+            QueryAccountBills.ACCOUNTID);
 
         QueryAccountBills queryAccountBills = new QueryAccountBills(getActivity());
         selectedAccounts = new ArrayList<>();
@@ -543,11 +543,8 @@ public class CashFlowReportListFragment
             item.setChecked(true);
             AccountFilterSupport.saveFilterMode(settings, PREF_FILTER_MODE, item.getItemId());
             if (item.getItemId() == R.id.menu_account_filter_custom) {
-                List<Long> selected = AccountFilterSupport.parseSelectedAccountIds(settings, PREF_FILTER_CUSTOM);
-                AccountFilterSupport.showAccountSelectionDialog(requireContext(), selected, selectedIds -> {
-                    AccountFilterSupport.saveSelectedAccountIds(settings, PREF_FILTER_CUSTOM, selectedIds);
-                    getActivity().recreate();
-                });
+                AccountFilterSupport.showAndPersistAccountSelectionDialog(
+                        requireContext(), settings, PREF_FILTER_CUSTOM, () -> getActivity().recreate());
                 return true;
             }
             getActivity().recreate();

--- a/app/src/main/res/menu/menu_cashflow.xml
+++ b/app/src/main/res/menu/menu_cashflow.xml
@@ -27,17 +27,17 @@
         <menu>
             <group android:checkableBehavior="single">
                 <item
-                    android:id="@+id/menu_cashflow_all"
-                    android:title="@string/menu_cashflow_all" />
+                    android:id="@+id/menu_account_filter_all"
+                    android:title="@string/menu_account_filter_all" />
                 <item
-                    android:id="@+id/menu_cashflow_open"
-                    android:title="@string/menu_cashflow_open" />
+                    android:id="@+id/menu_account_filter_open"
+                    android:title="@string/menu_account_filter_open" />
                 <item
-                    android:id="@+id/menu_cashflow_favorite"
-                    android:title="@string/menu_cashflow_favorite" />
+                    android:id="@+id/menu_account_filter_favorite"
+                    android:title="@string/menu_account_filter_favorite" />
                 <item
-                    android:id="@+id/menu_cashflow_custom"
-                    android:title="@string/menu_cashflow_custom" />
+                    android:id="@+id/menu_account_filter_custom"
+                    android:title="@string/menu_account_filter_custom" />
             </group>
             <item
                 android:id="@+id/menu_cashflow_24_months"

--- a/app/src/main/res/menu/menu_period_picker.xml
+++ b/app/src/main/res/menu/menu_period_picker.xml
@@ -21,6 +21,7 @@
     <item
         android:id="@+id/menu_period"
         android:icon="?attr/ic_action_calendar_day"
+        android:orderInCategory="200"
         android:title="@string/time_frame"
         app:showAsAction="ifRoom">
         <menu>

--- a/app/src/main/res/menu/menu_report.xml
+++ b/app/src/main/res/menu/menu_report.xml
@@ -20,6 +20,7 @@
 
     <item
         android:id="@+id/menu_chart"
+      android:orderInCategory="100"
         android:title="@string/show_chart"
         android:visible="false"
         app:showAsAction="always"/>

--- a/app/src/main/res/menu/menu_report_account_filter.xml
+++ b/app/src/main/res/menu/menu_report_account_filter.xml
@@ -5,7 +5,7 @@
     <item
         android:id="@+id/menu_account_filter"
         android:icon="@drawable/ic_action_settings_dark"
-        android:orderInCategory="900"
+        android:orderInCategory="300"
         android:title="@string/settings"
         app:showAsAction="always">
         <menu>

--- a/app/src/main/res/menu/menu_report_account_filter.xml
+++ b/app/src/main/res/menu/menu_report_account_filter.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/menu_account_filter"
+        android:icon="@drawable/ic_action_settings_dark"
+        android:orderInCategory="900"
+        android:title="@string/settings"
+        app:showAsAction="always">
+        <menu>
+            <group android:checkableBehavior="single">
+                <item
+                    android:id="@+id/menu_account_filter_all"
+                    android:title="@string/menu_account_filter_all" />
+                <item
+                    android:id="@+id/menu_account_filter_open"
+                    android:title="@string/menu_account_filter_open"
+                    android:checked="true" />
+                <item
+                    android:id="@+id/menu_account_filter_favorite"
+                    android:title="@string/menu_account_filter_favorite" />
+                <item
+                    android:id="@+id/menu_account_filter_custom"
+                    android:title="@string/menu_account_filter_custom" />
+            </group>
+        </menu>
+    </item>
+
+</menu>

--- a/app/src/main/res/menu/menu_report_income_vs_expenses.xml
+++ b/app/src/main/res/menu/menu_report_income_vs_expenses.xml
@@ -20,11 +20,13 @@
     <item
         android:id="@+id/menu_chart"
         android:icon="?attr/ic_action_bargraph"
+        android:orderInCategory="100"
         android:title="@string/show_chart"
         app:showAsAction="always"/>
     <item
         android:id="@+id/menu_sort"
         android:icon="?attr/ic_action_sort_1"
+        android:orderInCategory="150"
         android:title="@string/sort"
         app:showAsAction="always">
         <menu>
@@ -38,12 +40,6 @@
                     android:title="@string/sort_by_desceding"/>
             </group>
         </menu>
-    </item>
-    <item
-        android:id="@+id/menu_period"
-        android:icon="?attr/ic_action_calendar_day"
-        app:showAsAction="always"
-        android:title="@string/select_the_years_to_be_displayed">
     </item>
 
 </menu>

--- a/app/src/main/res/menu/menu_summary_of_accounts.xml
+++ b/app/src/main/res/menu/menu_summary_of_accounts.xml
@@ -51,17 +51,17 @@
         <menu>
             <group android:checkableBehavior="single">
                 <item
-                    android:id="@+id/menu_summary_accounts_all"
-                    android:title="@string/menu_cashflow_all" />
+                    android:id="@+id/menu_account_filter_all"
+                    android:title="@string/menu_account_filter_all" />
                 <item
-                    android:id="@+id/menu_summary_accounts_open"
-                    android:title="@string/menu_cashflow_open" />
+                    android:id="@+id/menu_account_filter_open"
+                    android:title="@string/menu_account_filter_open" />
                 <item
-                    android:id="@+id/menu_summary_accounts_favorite"
-                    android:title="@string/menu_cashflow_favorite" />
+                    android:id="@+id/menu_account_filter_favorite"
+                    android:title="@string/menu_account_filter_favorite" />
                 <item
-                    android:id="@+id/menu_summary_accounts_custom"
-                    android:title="@string/menu_cashflow_custom" />
+                    android:id="@+id/menu_account_filter_custom"
+                    android:title="@string/menu_account_filter_custom" />
             </group>
         </menu>
     </item>

--- a/app/src/main/res/values-ar-rSA/strings.xml
+++ b/app/src/main/res/values-ar-rSA/strings.xml
@@ -579,10 +579,10 @@
     <string name="menu_show_inactive">عرض الغير نشط</string>
     <!--- New navigation mode -->
     <!--Upload/Downlaod warnning -->
-    <string name="menu_cashflow_all">كافة الحسابات</string>
-    <string name="menu_cashflow_open">الحسابات المفتوحة</string>
-    <string name="menu_cashflow_favorite">الحسابات المفضلة</string>
-    <string name="menu_cashflow_custom">حدد الحسابات&#8230;</string>
+    <string name="menu_account_filter_all">كافة الحسابات</string>
+    <string name="menu_account_filter_open">الحسابات المفتوحة</string>
+    <string name="menu_account_filter_favorite">الحسابات المفضلة</string>
+    <string name="menu_account_filter_custom">حدد الحسابات&#8230;</string>
     <!-- Merge -->
     <!-- Error Handling -->
     <!-- changelog -->

--- a/app/src/main/res/values-bs-rBA/strings.xml
+++ b/app/src/main/res/values-bs-rBA/strings.xml
@@ -675,7 +675,7 @@
     <!-- Builder button -->
     <!--- New navigation mode -->
     <!--Upload/Downlaod warnning -->
-    <string name="menu_cashflow_all">Svi računi</string>
+    <string name="menu_account_filter_all">Svi računi</string>
     <!-- Merge -->
     <!-- Error Handling -->
     <!-- changelog -->

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -664,7 +664,7 @@
     <!-- Builder button -->
     <!--- New navigation mode -->
     <!--Upload/Downlaod warnning -->
-    <string name="menu_cashflow_all">Všechny účty</string>
+    <string name="menu_account_filter_all">Všechny účty</string>
     <!-- Merge -->
     <!-- Error Handling -->
     <!-- changelog -->

--- a/app/src/main/res/values-da-rDK/strings.xml
+++ b/app/src/main/res/values-da-rDK/strings.xml
@@ -719,7 +719,7 @@
     <!-- Builder button -->
     <!--- New navigation mode -->
     <!--Upload/Downlaod warnning -->
-    <string name="menu_cashflow_all">Alle konti</string>
+    <string name="menu_account_filter_all">Alle konti</string>
     <!-- Merge -->
     <!-- Error Handling -->
     <!-- changelog -->

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -805,10 +805,10 @@
     <string name="local_file_change">Anzeige für lokale Dateiänderungen: </string>
     <string name="msg_uploading_overwrite">Hochladen wird Ihre Remote-Version überschreiben.\nMöchten Sie fortfahren?</string>
     <string name="msg_downloading_overwrite">Das Herunterladen wird Ihre lokale Version überschreiben.\nMöchten Sie fortfahren?</string>
-    <string name="menu_cashflow_all">Alle Konten</string>
-    <string name="menu_cashflow_open">Offene Konten</string>
-    <string name="menu_cashflow_favorite">Favorisierte Konten</string>
-    <string name="menu_cashflow_custom">Konten wählen&#8230;</string>
+    <string name="menu_account_filter_all">Alle Konten</string>
+    <string name="menu_account_filter_open">Offene Konten</string>
+    <string name="menu_account_filter_favorite">Favorisierte Konten</string>
+    <string name="menu_account_filter_custom">Konten wählen&#8230;</string>
     <string name="cash_ledger">Kassenbuch</string>
     <!-- Merge -->
     <string name="merge_take_ours">Lokal behalten</string>

--- a/app/src/main/res/values-el-rGR/strings.xml
+++ b/app/src/main/res/values-el-rGR/strings.xml
@@ -674,7 +674,7 @@
     <!-- Builder button -->
     <!--- New navigation mode -->
     <!--Upload/Downlaod warnning -->
-    <string name="menu_cashflow_all">Όλοι οι λογαριασμοί</string>
+    <string name="menu_account_filter_all">Όλοι οι λογαριασμοί</string>
     <!-- Merge -->
     <!-- Error Handling -->
     <!-- changelog -->

--- a/app/src/main/res/values-en-rUS/strings.xml
+++ b/app/src/main/res/values-en-rUS/strings.xml
@@ -786,7 +786,7 @@
     <string name="local_file_change">Local file changes indicator: </string>
     <string name="msg_uploading_overwrite">Uploading will overwrite your remote version.\nDo you want to continue?</string>
     <string name="msg_downloading_overwrite">Downloading will overwrite your local version.\nDo you want to continue?</string>
-    <string name="menu_cashflow_all">All Accounts</string>
+    <string name="menu_account_filter_all">All Accounts</string>
     <!-- Merge -->
     <!-- Error Handling -->
     <!-- changelog -->

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -747,8 +747,8 @@
     <!--- New navigation mode -->
     <string name="remember_later">Recordarme más tarde</string>
     <!--Upload/Downlaod warnning -->
-    <string name="menu_cashflow_all">Todas las cuentas</string>
-    <string name="menu_cashflow_open">Abrir Cuentas</string>
+    <string name="menu_account_filter_all">Todas las cuentas</string>
+    <string name="menu_account_filter_open">Abrir Cuentas</string>
     <!-- Merge -->
     <!-- Error Handling -->
     <string name="forecast_calculate">Calculando la Predicción. Por favor espere&#8230;</string>

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -266,7 +266,7 @@
     <!-- Builder button -->
     <!--- New navigation mode -->
     <!--Upload/Downlaod warnning -->
-    <string name="menu_cashflow_all">Kõik kontod</string>
+    <string name="menu_account_filter_all">Kõik kontod</string>
     <!-- Merge -->
     <!-- Error Handling -->
     <!-- changelog -->

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -675,7 +675,7 @@
     <!-- Builder button -->
     <!--- New navigation mode -->
     <!--Upload/Downlaod warnning -->
-    <string name="menu_cashflow_all">Lahat ng account</string>
+    <string name="menu_account_filter_all">Lahat ng account</string>
     <!-- Merge -->
     <!-- Error Handling -->
     <!-- changelog -->

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -705,8 +705,8 @@
     <string name="CLEAR_ALL">Effacer tout</string>
     <!--- New navigation mode -->
     <!--Upload/Downlaod warnning -->
-    <string name="menu_cashflow_all">Tous les comptes</string>
-    <string name="menu_cashflow_custom">Sélectionnez les comptes&#8230;</string>
+    <string name="menu_account_filter_all">Tous les comptes</string>
+    <string name="menu_account_filter_custom">Sélectionnez les comptes&#8230;</string>
     <!-- Merge -->
     <!-- Error Handling -->
     <!-- changelog -->

--- a/app/src/main/res/values-hr-rHR/strings.xml
+++ b/app/src/main/res/values-hr-rHR/strings.xml
@@ -776,10 +776,10 @@
     <string name="download_warning">Upozorenje o preuzimanju</string>
     <string name="msg_uploading_overwrite">Prijenos će prepisati tvoju udaljenu verziju.\nŽeliš li nastaviti?</string>
     <string name="msg_downloading_overwrite">Preuzimanje će prepisati tvoju lokalnu verziju.\nŽeliš li nastaviti?</string>
-    <string name="menu_cashflow_all">Svi računi</string>
-    <string name="menu_cashflow_open">Otvori račune</string>
-    <string name="menu_cashflow_favorite">Favorizirani računi</string>
-    <string name="menu_cashflow_custom">Odaberi račune &#8230;</string>
+    <string name="menu_account_filter_all">Svi računi</string>
+    <string name="menu_account_filter_open">Otvori račune</string>
+    <string name="menu_account_filter_favorite">Favorizirani računi</string>
+    <string name="menu_account_filter_custom">Odaberi račune &#8230;</string>
     <string name="cash_ledger">Knjiga gotovine</string>
     <!-- Merge -->
     <string name="merge_take_ours">Zadrži lokalno</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -801,10 +801,10 @@
     <string name="local_file_change">Helyi fájlváltozások jelzője: </string>
     <string name="msg_uploading_overwrite">A feltöltés felülírja a távoli verziót.\nFolytatja?</string>
     <string name="msg_downloading_overwrite">A letöltés felülírja a helyi verziót.\nFolytatja?</string>
-    <string name="menu_cashflow_all">Minden számla</string>
-    <string name="menu_cashflow_open">Nyitott számlák</string>
-    <string name="menu_cashflow_favorite">Kedvenc számlák</string>
-    <string name="menu_cashflow_custom">Számlák kijelölése&#8230;</string>
+    <string name="menu_account_filter_all">Minden számla</string>
+    <string name="menu_account_filter_open">Nyitott számlák</string>
+    <string name="menu_account_filter_favorite">Kedvenc számlák</string>
+    <string name="menu_account_filter_custom">Számlák kijelölése&#8230;</string>
     <string name="cash_ledger">Készpénzes főkönyv</string>
     <!-- Merge -->
     <string name="merge_take_ours">Helyi megőrzés</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -675,7 +675,7 @@
     <!-- Builder button -->
     <!--- New navigation mode -->
     <!--Upload/Downlaod warnning -->
-    <string name="menu_cashflow_all">Semua akun</string>
+    <string name="menu_account_filter_all">Semua akun</string>
     <!-- Merge -->
     <!-- Error Handling -->
     <!-- changelog -->

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -801,10 +801,10 @@
     <string name="local_file_change">Indicatore di modifiche file locali: </string>
     <string name="msg_uploading_overwrite">Il caricamento sovrascriverà la tua versione remota.\nVuoi continuare?</string>
     <string name="msg_downloading_overwrite">Il download sovrascriverà la tua versione locale.\nVuoi continuare?</string>
-    <string name="menu_cashflow_all">Tutti i conti</string>
-    <string name="menu_cashflow_open">Conti aperti</string>
-    <string name="menu_cashflow_favorite">Conti Preferiti</string>
-    <string name="menu_cashflow_custom">Seleziona conti&#8230;</string>
+    <string name="menu_account_filter_all">Tutti i conti</string>
+    <string name="menu_account_filter_open">Conti aperti</string>
+    <string name="menu_account_filter_favorite">Conti Preferiti</string>
+    <string name="menu_account_filter_custom">Seleziona conti&#8230;</string>
     <string name="cash_ledger">Libro Cassa</string>
     <!-- Merge -->
     <string name="merge_take_ours">Mantieni versione locale</string>

--- a/app/src/main/res/values-iw-rIL/strings.xml
+++ b/app/src/main/res/values-iw-rIL/strings.xml
@@ -675,7 +675,7 @@
     <!-- Builder button -->
     <!--- New navigation mode -->
     <!--Upload/Downlaod warnning -->
-    <string name="menu_cashflow_all">כל החשבונות</string>
+    <string name="menu_account_filter_all">כל החשבונות</string>
     <!-- Merge -->
     <!-- Error Handling -->
     <!-- changelog -->

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -675,7 +675,7 @@
     <!-- Builder button -->
     <!--- New navigation mode -->
     <!--Upload/Downlaod warnning -->
-    <string name="menu_cashflow_all">すべての口座</string>
+    <string name="menu_account_filter_all">すべての口座</string>
     <!-- Merge -->
     <!-- Error Handling -->
     <!-- changelog -->

--- a/app/src/main/res/values-nl-rNL/strings.xml
+++ b/app/src/main/res/values-nl-rNL/strings.xml
@@ -805,10 +805,10 @@
     <string name="local_file_change">Indicator voor lokale bestandswijzigingen: </string>
     <string name="msg_uploading_overwrite">Uploaden overschrijft uw externe versie.\nWilt u doorgaan?</string>
     <string name="msg_downloading_overwrite">Downloaden overschrijft uw lokale versie.\nWilt u doorgaan?</string>
-    <string name="menu_cashflow_all">Alle rekeningen</string>
-    <string name="menu_cashflow_open">Account openen</string>
-    <string name="menu_cashflow_favorite">Favoriete rekening</string>
-    <string name="menu_cashflow_custom">Selecteer rekeningen...</string>
+    <string name="menu_account_filter_all">Alle rekeningen</string>
+    <string name="menu_account_filter_open">Account openen</string>
+    <string name="menu_account_filter_favorite">Favoriete rekening</string>
+    <string name="menu_account_filter_custom">Selecteer rekeningen...</string>
     <string name="cash_ledger">Kasboek</string>
     <!-- Merge -->
     <string name="merge_take_ours">Lokale gegevens behouden</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -751,10 +751,10 @@
     <string name="local_file_change">Zdalny wskaźnik zmian pliku: </string>
     <string name="msg_uploading_overwrite">Przesyłanie nadpisze twoją zdalną wersję.\nCzy chcesz kontynuować?</string>
     <string name="msg_downloading_overwrite">Pobieranie nadpisze twoją zdalną wersję.\nCzy chcesz kontynuować?</string>
-    <string name="menu_cashflow_all">Wszystkie konta</string>
-    <string name="menu_cashflow_open">Otwarte Konta</string>
-    <string name="menu_cashflow_favorite">Ulubione konta</string>
-    <string name="menu_cashflow_custom">Wybierz konta</string>
+    <string name="menu_account_filter_all">Wszystkie konta</string>
+    <string name="menu_account_filter_open">Otwarte Konta</string>
+    <string name="menu_account_filter_favorite">Ulubione konta</string>
+    <string name="menu_account_filter_custom">Wybierz konta</string>
     <string name="cash_ledger">Księga kasowa</string>
     <!-- Merge -->
     <string name="merge_take_ours">Przechowuj lokalnie</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -801,10 +801,10 @@
     <string name="local_file_change">Indicador de alterações no arquivo local: </string>
     <string name="msg_uploading_overwrite">Fazer uploading irá substituir a sua versão remota.\nVocê quer continuar?</string>
     <string name="msg_downloading_overwrite">Baixando irá substituir a sua versão local.\nDeseja continuar?</string>
-    <string name="menu_cashflow_all">Todas as contas</string>
-    <string name="menu_cashflow_open">Contas Abertas</string>
-    <string name="menu_cashflow_favorite">Contas Favoritas</string>
-    <string name="menu_cashflow_custom">Selecionar Contas&#8230;</string>
+    <string name="menu_account_filter_all">Todas as contas</string>
+    <string name="menu_account_filter_open">Contas Abertas</string>
+    <string name="menu_account_filter_favorite">Contas Favoritas</string>
+    <string name="menu_account_filter_custom">Selecionar Contas&#8230;</string>
     <string name="cash_ledger">Contabilidade de Caixa</string>
     <!-- Merge -->
     <string name="merge_take_ours">Deixar local</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -684,7 +684,7 @@ Toque para marcar a transação como atrasada</string>
     <!-- Builder button -->
     <!--- New navigation mode -->
     <!--Upload/Downlaod warnning -->
-    <string name="menu_cashflow_all">Todas as Contas</string>
+    <string name="menu_account_filter_all">Todas as Contas</string>
     <!-- Merge -->
     <!-- Error Handling -->
     <!-- changelog -->

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -606,7 +606,7 @@
     <!-- Builder button -->
     <!--- New navigation mode -->
     <!--Upload/Downlaod warnning -->
-    <string name="menu_cashflow_all">Toate conturile</string>
+    <string name="menu_account_filter_all">Toate conturile</string>
     <!-- Merge -->
     <!-- Error Handling -->
     <!-- changelog -->

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -799,10 +799,10 @@
     <string name="local_file_change">Индикатор изменений локального файла: </string>
     <string name="msg_uploading_overwrite">Загруженная версия перезапишет существующую.\nПродолжить?</string>
     <string name="msg_downloading_overwrite">Скачанная версия перезапишет существующую.\nПродолжить?</string>
-    <string name="menu_cashflow_all">Все счета</string>
-    <string name="menu_cashflow_open">Открытые счета</string>
-    <string name="menu_cashflow_favorite">Избранные счета</string>
-    <string name="menu_cashflow_custom">Выберите счета&#8230;</string>
+    <string name="menu_account_filter_all">Все счета</string>
+    <string name="menu_account_filter_open">Открытые счета</string>
+    <string name="menu_account_filter_favorite">Избранные счета</string>
+    <string name="menu_account_filter_custom">Выберите счета&#8230;</string>
     <string name="cash_ledger">Кассовая книга</string>
     <!-- Merge -->
     <string name="merge_take_ours">Сохранить локальное значение</string>

--- a/app/src/main/res/values-sk-rSK/strings.xml
+++ b/app/src/main/res/values-sk-rSK/strings.xml
@@ -640,7 +640,7 @@
     <!-- Builder button -->
     <!--- New navigation mode -->
     <!--Upload/Downlaod warnning -->
-    <string name="menu_cashflow_all">Všetky účty</string>
+    <string name="menu_account_filter_all">Všetky účty</string>
     <!-- Merge -->
     <!-- Error Handling -->
     <!-- changelog -->

--- a/app/src/main/res/values-sl-rSI/strings.xml
+++ b/app/src/main/res/values-sl-rSI/strings.xml
@@ -571,7 +571,7 @@
     <!-- Builder button -->
     <!--- New navigation mode -->
     <!--Upload/Downlaod warnning -->
-    <string name="menu_cashflow_all">Vsi računi</string>
+    <string name="menu_account_filter_all">Vsi računi</string>
     <!-- Merge -->
     <!-- Error Handling -->
     <!-- changelog -->

--- a/app/src/main/res/values-ta-rIN/strings.xml
+++ b/app/src/main/res/values-ta-rIN/strings.xml
@@ -799,10 +799,10 @@
     <string name="local_file_change">உள்ளூர் கோப்பு மாற்றங்கள் காட்டி:</string>
     <string name="msg_uploading_overwrite">பதிவேற்றினால் உங்கள் தொலைநிலைப் பதிப்பு மேலெழுதப்படும்.\nதொடர விரும்புகிறீர்களா?</string>
     <string name="msg_downloading_overwrite">பதிவிறக்குவது உங்கள் உள்ளூர் பதிப்பை மேலெழுதும்.\nதொடர விரும்புகிறீர்களா?</string>
-    <string name="menu_cashflow_all">அனைத்து கணக்குகளும்</string>
-    <string name="menu_cashflow_open">திறந்த கணக்குகள்</string>
-    <string name="menu_cashflow_favorite">பிடித்த கணக்குகள்</string>
-    <string name="menu_cashflow_custom">கணக்குகளைத் தேர்ந்தெடுக்கவும்&#8230;</string>
+    <string name="menu_account_filter_all">அனைத்து கணக்குகளும்</string>
+    <string name="menu_account_filter_open">திறந்த கணக்குகள்</string>
+    <string name="menu_account_filter_favorite">பிடித்த கணக்குகள்</string>
+    <string name="menu_account_filter_custom">கணக்குகளைத் தேர்ந்தெடுக்கவும்&#8230;</string>
     <string name="cash_ledger">பண பேரேடு</string>
     <!-- Merge -->
     <string name="merge_take_ours">மொபைல் கோப்புகளை வைத்திருங்கள்</string>

--- a/app/src/main/res/values-tl-rPH/strings.xml
+++ b/app/src/main/res/values-tl-rPH/strings.xml
@@ -675,7 +675,7 @@
     <!-- Builder button -->
     <!--- New navigation mode -->
     <!--Upload/Downlaod warnning -->
-    <string name="menu_cashflow_all">Lahat ng mga account</string>
+    <string name="menu_account_filter_all">Lahat ng mga account</string>
     <!-- Merge -->
     <!-- Error Handling -->
     <!-- changelog -->

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -745,7 +745,7 @@
     <string name="local_file_change">Yerel dosya değişiklikleri göstergesi:</string>
     <string name="msg_uploading_overwrite">Yükleme, uzak sürümünüzün üzerine yazacaktır.\nDevam etmek ister misin?</string>
     <string name="msg_downloading_overwrite">İndirilen dosya yerel sürümünüzün üzerine yazacak.\nDevam etmek ister misin?</string>
-    <string name="menu_cashflow_all">Tüm Hesaplar</string>
+    <string name="menu_account_filter_all">Tüm Hesaplar</string>
     <!-- Merge -->
     <!-- Error Handling -->
     <!-- changelog -->

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -720,7 +720,7 @@
     <!-- Builder button -->
     <!--- New navigation mode -->
     <!--Upload/Downlaod warnning -->
-    <string name="menu_cashflow_all">Всі рахунки</string>
+    <string name="menu_account_filter_all">Всі рахунки</string>
     <!-- Merge -->
     <!-- Error Handling -->
     <!-- changelog -->

--- a/app/src/main/res/values-ur-rIN/strings.xml
+++ b/app/src/main/res/values-ur-rIN/strings.xml
@@ -675,7 +675,7 @@
     <!-- Builder button -->
     <!--- New navigation mode -->
     <!--Upload/Downlaod warnning -->
-    <string name="menu_cashflow_all">تمام اکاؤنٹ</string>
+    <string name="menu_account_filter_all">تمام اکاؤنٹ</string>
     <!-- Merge -->
     <!-- Error Handling -->
     <!-- changelog -->

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -675,7 +675,7 @@
     <!-- Builder button -->
     <!--- New navigation mode -->
     <!--Upload/Downlaod warnning -->
-    <string name="menu_cashflow_all">تمام اکاؤنٹ</string>
+    <string name="menu_account_filter_all">تمام اکاؤنٹ</string>
     <!-- Merge -->
     <!-- Error Handling -->
     <!-- changelog -->

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -688,7 +688,7 @@
     <!-- Builder button -->
     <!--- New navigation mode -->
     <!--Upload/Downlaod warnning -->
-    <string name="menu_cashflow_all">Tất cả tài khoản</string>
+    <string name="menu_account_filter_all">Tất cả tài khoản</string>
     <!-- Merge -->
     <!-- Error Handling -->
     <!-- changelog -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -799,10 +799,10 @@
     <string name="local_file_change">本地文件变更指示器：</string>
     <string name="msg_uploading_overwrite">上传操作将覆盖您的远程版本。\n确定要继续吗？</string>
     <string name="msg_downloading_overwrite">下载操作将覆盖您的本地版本。\n确定要继续吗？</string>
-    <string name="menu_cashflow_all">所有账户</string>
-    <string name="menu_cashflow_open">打开账户</string>
-    <string name="menu_cashflow_favorite">收藏账户</string>
-    <string name="menu_cashflow_custom">选择账户</string>
+    <string name="menu_account_filter_all">所有账户</string>
+    <string name="menu_account_filter_open">打开账户</string>
+    <string name="menu_account_filter_favorite">收藏账户</string>
+    <string name="menu_account_filter_custom">选择账户</string>
     <string name="cash_ledger">现金账本</string>
     <!-- Merge -->
     <string name="merge_take_ours">保留本地版本</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -677,7 +677,7 @@
     <!-- Builder button -->
     <!--- New navigation mode -->
     <!--Upload/Downlaod warnning -->
-    <string name="menu_cashflow_all">所有帳戶</string>
+    <string name="menu_account_filter_all">所有帳戶</string>
     <!-- Merge -->
     <!-- Error Handling -->
     <!-- changelog -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -904,10 +904,10 @@
     <string name="local_file_change">Local file changes indicator: </string>
     <string name="msg_uploading_overwrite">Uploading will overwrite your remote version.\nDo you want to continue?</string>
     <string name="msg_downloading_overwrite">Downloading will overwrite your local version.\nDo you want to continue?</string>
-    <string name="menu_cashflow_all">All Accounts</string>
-    <string name="menu_cashflow_open">Open Accounts</string>
-    <string name="menu_cashflow_favorite">Favorite Accounts</string>
-    <string name="menu_cashflow_custom">Select Accounts…</string>
+    <string name="menu_account_filter_all">All Accounts</string>
+    <string name="menu_account_filter_open">Open Accounts</string>
+    <string name="menu_account_filter_favorite">Favorite Accounts</string>
+    <string name="menu_account_filter_custom">Select Accounts…</string>
     <string name="cash_ledger">Cash Ledger</string>
 
     <!-- Merge -->


### PR DESCRIPTION
This PR consolidates report filtering logic by reusing shared helpers for account filtering and date ranges across report fragments. Now also the payee and categories reports use the account filter and the income vs expenses report uses the more flexible date range filter (supersedes https://github.com/moneymanagerex/android-money-manager-ex/pull/2874). This ensures less duplicated code, more consistency between reports, and easier maintenance.
Note that I renamed some strings because they are not specific to the cashflow report anymore. I updated the names across all available translations.
For transparency again, I used LLMs to help me creating this PR.