### PR TITLE
Add filtered accounts to search parameters

### DIFF
--- a/app/src/main/java/com/money/manager/ex/reports/CategoriesReportFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/CategoriesReportFragment.java
@@ -301,6 +301,7 @@ public class CategoriesReportFragment
         parameters.category = category;
         parameters.dateFrom = mDateFrom;
         parameters.dateTo = mDateTo;
+        parameters.accountFilterWhere = getAccountFilterSelection(QueryMobileData.ACCOUNTID);
 
         showSearchActivityFor(parameters);
     }

--- a/app/src/main/java/com/money/manager/ex/reports/IncomeVsExpensesListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/IncomeVsExpensesListFragment.java
@@ -48,6 +48,7 @@ import com.money.manager.ex.common.MmxCursorLoader;
 import com.money.manager.ex.core.IntentFactory;
 import com.money.manager.ex.core.UIHelper;
 import com.money.manager.ex.currency.CurrencyService;
+import com.money.manager.ex.database.QueryAllData;
 import com.money.manager.ex.database.QueryMobileData;
 import com.money.manager.ex.database.QueryReportIncomeVsExpenses;
 import com.money.manager.ex.database.SQLDataSet;
@@ -489,6 +490,11 @@ public class IncomeVsExpensesListFragment
                 }
                 dateTime.lastDayOfMonth();
                 params.dateTo = dateTime.toDate();
+
+                int mode = getAccountFilterMode();
+                LookAndFeelSettings settings = new AppSettings(requireContext()).getLookAndFeelSettings();
+                params.accountFilterWhere = AccountFilterSupport.getSelectionForAccountIdColumn(
+                        mode, settings, PREF_FILTER_CUSTOM, QueryAllData.ACCOUNTID);
 
                 Intent intent = IntentFactory.getSearchIntent(getActivity(), params);
                 startActivity(intent);

--- a/app/src/main/java/com/money/manager/ex/reports/PayeeReportFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/PayeeReportFragment.java
@@ -292,6 +292,7 @@ public class PayeeReportFragment
         parameters.payeeName = payee.getName();
         parameters.dateFrom = mDateFrom;
         parameters.dateTo = mDateTo;
+        parameters.accountFilterWhere = getAccountFilterSelection(QueryMobileData.ACCOUNTID);
 
         showSearchActivityFor(parameters);
     }

--- a/app/src/main/java/com/money/manager/ex/search/SearchParameters.java
+++ b/app/src/main/java/com/money/manager/ex/search/SearchParameters.java
@@ -34,6 +34,7 @@ public class SearchParameters {
 
     // Account
     public Long accountId;
+    public String accountFilterWhere;
 
     // Currency
     public Long currencyId;

--- a/app/src/main/java/com/money/manager/ex/search/SearchParametersFragment.java
+++ b/app/src/main/java/com/money/manager/ex/search/SearchParametersFragment.java
@@ -475,6 +475,10 @@ public class SearchParametersFragment
             );
         }
 
+        if (!TextUtils.isEmpty(searchParameters.accountFilterWhere)) {
+            where.addStatement(searchParameters.accountFilterWhere);
+        }
+
         // currency
         if (searchParameters.currencyId != null && searchParameters.currencyId != Constants.NOT_SET) {
             where.addStatement(QueryAllData.CURRENCYID, "=", searchParameters.currencyId);


### PR DESCRIPTION
In #2876, I forgot to add the filtered accounts to the search parameters, when clicking on a category, payee, or month. This fixes that.