### PR TITLE
Translate week day in dates and use date format

### DIFF
--- a/app/src/main/java/com/money/manager/ex/investment/InvestmentTransactionEditActivity.java
+++ b/app/src/main/java/com/money/manager/ex/investment/InvestmentTransactionEditActivity.java
@@ -387,8 +387,10 @@ public class InvestmentTransactionEditActivity
     private void displayStock(Stock stock, InvestmentTransactionViewHolder viewHolder) {
         if (mAccount == null) return;
 
-        // Date
-        String dateDisplay = new MmxDate(stock.getPurchaseDate()).toString(Constants.LONG_DATE_PATTERN);
+        // Date (use user-configured format with weekday prefix to match normal transactions)
+        String userPattern = dateTimeUtilsLazy.get().getUserDatePattern(InvestmentTransactionEditActivity.this);
+        String format = "EEE, " + userPattern;
+        String dateDisplay = dateTimeUtilsLazy.get().format(stock.getPurchaseDate(), format);
         viewHolder.dateView.setText(dateDisplay);
 
         // Account.
@@ -927,7 +929,9 @@ public class InvestmentTransactionEditActivity
     }
 
     private void showDate(Date date) {
-        String display = new MmxDate(date).toString(Constants.LONG_DATE_PATTERN);
+        String userPattern = dateTimeUtilsLazy.get().getUserDatePattern(InvestmentTransactionEditActivity.this);
+        String format = "EEE, " + userPattern;
+        String display = dateTimeUtilsLazy.get().format(date, format);
         mViewHolder.dateView.setText(display);
     }
 

--- a/app/src/main/java/com/money/manager/ex/utils/MmxDateTimeUtils.java
+++ b/app/src/main/java/com/money/manager/ex/utils/MmxDateTimeUtils.java
@@ -50,7 +50,14 @@ public class MmxDateTimeUtils {
     @Inject
     public MmxDateTimeUtils() {
 
+        try {
+            _locale = MmexApplication.getApp().getAppLocale();
+        } catch (Exception e) {
+            _locale = Locale.getDefault();
+        }
     }
+
+
 
     public MmxDateTimeUtils(Locale locale) {
         _locale = locale;

--- a/app/src/main/java/com/money/manager/ex/utils/MmxDateTimeUtils.java
+++ b/app/src/main/java/com/money/manager/ex/utils/MmxDateTimeUtils.java
@@ -57,8 +57,6 @@ public class MmxDateTimeUtils {
         }
     }
 
-
-
     public MmxDateTimeUtils(Locale locale) {
         _locale = locale;
     }


### PR DESCRIPTION
I noticed that week days in dates from transactions are not translated, but are always English (e.g., "Wed" for Wednesday). This should respect the selected locale. I also noticed that I forgot to apply the selected date format for the dates in the share transactions.