### PR TITLE
Make whole table in portfolio scrollable instead of single rows

### DIFF
--- a/app/src/main/java/com/money/manager/ex/investment/PortfolioListAdapter.java
+++ b/app/src/main/java/com/money/manager/ex/investment/PortfolioListAdapter.java
@@ -21,8 +21,6 @@ import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.HorizontalScrollView;
-import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -178,16 +176,14 @@ public class PortfolioListAdapter extends ListAdapter<Stock, PortfolioListAdapte
             unrealizedGLAmountTextView = itemView.findViewById(R.id.unrealizedGLAmountTextView);
             unrealizedGLPercentTextView = itemView.findViewById(R.id.unrealizedGLPercentTextView);
 
-            LinearLayout mainLayout = (LinearLayout) ((HorizontalScrollView) itemView).getChildAt(0);
-
-            mainLayout.setOnClickListener(v -> {
+            itemView.setOnClickListener(v -> {
                 int position = getBindingAdapterPosition();
                 if (position != RecyclerView.NO_POSITION && listener != null) {
                     listener.onItemClick(getItem(position).getId());
                 }
             });
 
-            mainLayout.setOnLongClickListener(v -> {
+            itemView.setOnLongClickListener(v -> {
                 int position = getBindingAdapterPosition();
                 if (position != RecyclerView.NO_POSITION && longClickListener != null) {
                     Stock stock = getItem(position);

--- a/app/src/main/res/layout/fragment_portfolio.xml
+++ b/app/src/main/res/layout/fragment_portfolio.xml
@@ -69,11 +69,18 @@
             android:layout_height="0dp"
             android:layout_weight="1">
 
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/recyclerView"
+            <HorizontalScrollView
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:drawSelectorOnTop="false" />
+                android:scrollbars="none">
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/recyclerView"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:drawSelectorOnTop="false" />
+
+            </HorizontalScrollView>
 
             <ScrollView
                 android:id="@+id/emptyViewScroll"

--- a/app/src/main/res/layout/item_portfolio.xml
+++ b/app/src/main/res/layout/item_portfolio.xml
@@ -15,19 +15,13 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<HorizontalScrollView
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
+    android:layout_width="wrap_content"
     android:layout_height="@dimen/mmx_list_item_height"
-    android:fillViewport="true"
-    android:scrollbars="none">
-
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:orientation="horizontal"
-            android:gravity="center_vertical"
-            android:paddingVertical="@dimen/mmx_margin_bottom_top">
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:paddingVertical="@dimen/mmx_margin_bottom_top">
 
                 <!-- Column 1: Name | Symbol -->
                 <LinearLayout
@@ -135,4 +129,3 @@
                             android:paddingVertical="2dp"/>
                 </LinearLayout>
         </LinearLayout>
-</HorizontalScrollView>


### PR DESCRIPTION
Currently, each single row in the portfolio is scrollable in the horizontal direction independently. However, I find it more intuitive to scroll the whole table instead.