### PR TITLE
Add realized gain/loss and header in portfolio

### DIFF
--- a/app/src/main/java/com/money/manager/ex/investment/PortfolioFragment.java
+++ b/app/src/main/java/com/money/manager/ex/investment/PortfolioFragment.java
@@ -563,71 +563,7 @@ public class PortfolioFragment extends BaseRecyclerFragment {
             TransactionLinkRepository linkRepo,
             ShareInfoRepository shareInfoRepo,
             AccountTransactionRepository txRepo) {
-        List<TransactionLink> links = getStockLinks(linkRepo, stockId);
-        if (links == null || links.isEmpty()) {
-            return new PortfolioListAdapter.RealizedGainLoss(MoneyFactory.fromDouble(0), 0.0);
-        }
-
-        List<TradeData> trades = new ArrayList<>();
-        for (TransactionLink link : links) {
-            if (link == null || link.getCheckingAccountId() == null) continue;
-
-            Long transactionId = link.getCheckingAccountId();
-            com.money.manager.ex.domainmodel.ShareInfo shareInfo = shareInfoRepo.loadByTransactionId(transactionId);
-            if (shareInfo == null) continue;
-
-            AccountTransaction tx = txRepo.load(transactionId);
-            Date txDate = tx != null ? tx.getDate() : null;
-
-            double shares = shareInfo.getShareNumber() != null ? shareInfo.getShareNumber() : 0.0;
-            double price = shareInfo.getSharePrice() != null ? shareInfo.getSharePrice() : 0.0;
-            double commission = shareInfo.getShareCommission() != null ? shareInfo.getShareCommission() : 0.0;
-            trades.add(new TradeData(transactionId, txDate, shares, price, commission));
-        }
-
-        trades.sort(Comparator
-                .comparing((TradeData t) -> t.date, Comparator.nullsLast(Date::compareTo))
-                .thenComparingLong(t -> t.transactionId));
-
-        double heldShares = 0.0;
-        double heldCostBasis = 0.0;
-        double realizedAmount = 0.0;
-        double realizedCostBasis = 0.0;
-
-        for (TradeData trade : trades) {
-            if (trade.shares > 0) {
-                heldShares += trade.shares;
-                heldCostBasis += (trade.shares * trade.price) + trade.commission;
-                continue;
-            }
-
-            if (trade.shares >= 0) {
-                continue;
-            }
-
-            double soldShares = Math.abs(trade.shares);
-            double proceeds = (soldShares * trade.price) - trade.commission;
-            double averageCost = heldShares > 0 ? (heldCostBasis / heldShares) : 0.0;
-            double sharesMatched = Math.min(soldShares, Math.max(0.0, heldShares));
-            double costRemoved = sharesMatched * averageCost;
-
-            realizedAmount += proceeds - costRemoved;
-            realizedCostBasis += costRemoved;
-
-            heldShares = Math.max(0.0, heldShares - sharesMatched);
-            heldCostBasis = Math.max(0.0, heldCostBasis - costRemoved);
-            if (heldShares == 0.0) {
-                heldCostBasis = 0.0;
-            }
-        }
-
-        double realizedPercent = realizedCostBasis > 0
-                ? (realizedAmount / realizedCostBasis) * 100.0
-                : 0.0;
-
-        return new PortfolioListAdapter.RealizedGainLoss(
-                MoneyFactory.fromDouble(realizedAmount),
-                realizedPercent);
+        return new RealizedGainLossCalculator(linkRepo, shareInfoRepo, txRepo).calculate(stockId);
     }
 
     private boolean isHideZeroSharesEnabled() {
@@ -691,7 +627,7 @@ public class PortfolioFragment extends BaseRecyclerFragment {
         return true;
     }
 
-    private List<TransactionLink> getStockLinks(TransactionLinkRepository linkRepo, long stockId) {
+        private static List<TransactionLink> getStockLinks(TransactionLinkRepository linkRepo, long stockId) {
         return linkRepo.query(
                 new com.money.manager.ex.datalayer.Select(linkRepo.getAllColumns())
                         .where("LOWER(" + TransactionLink.LINKTYPE + ")=? AND "
@@ -785,6 +721,136 @@ public class PortfolioFragment extends BaseRecyclerFragment {
             this.shares = shares;
             this.price = price;
             this.commission = commission;
+        }
+
+        private boolean isBuy() {
+            return shares > 0.0;
+        }
+
+        private boolean isSell() {
+            return shares < 0.0;
+        }
+    }
+
+    private static final class RealizedGainLossCalculator {
+        private final TransactionLinkRepository linkRepo;
+        private final ShareInfoRepository shareInfoRepo;
+        private final AccountTransactionRepository txRepo;
+
+        private RealizedGainLossCalculator(TransactionLinkRepository linkRepo,
+                                           ShareInfoRepository shareInfoRepo,
+                                           AccountTransactionRepository txRepo) {
+            this.linkRepo = linkRepo;
+            this.shareInfoRepo = shareInfoRepo;
+            this.txRepo = txRepo;
+        }
+
+        private PortfolioListAdapter.RealizedGainLoss calculate(long stockId) {
+            List<TradeData> trades = loadTrades(stockId);
+            if (trades.isEmpty()) {
+                return zeroResult();
+            }
+
+            trades.sort(Comparator
+                    .comparing((TradeData trade) -> trade.date, Comparator.nullsLast(Date::compareTo))
+                    .thenComparingLong(trade -> trade.transactionId));
+
+            Money realizedAmount = MoneyFactory.fromDouble(0);
+            double realizedCostBasis = 0.0;
+            Position position = new Position();
+
+            for (TradeData trade : trades) {
+                if (trade.isBuy()) {
+                    position.applyBuy(trade);
+                    continue;
+                }
+                if (trade.isSell()) {
+                    Result result = position.applySell(trade);
+                    realizedAmount = realizedAmount.add(MoneyFactory.fromDouble(result.realizedAmount));
+                    realizedCostBasis += result.realizedCostBasis;
+                }
+            }
+
+            double realizedPercent = realizedCostBasis > 0.0
+                    ? (realizedAmount.toDouble() / realizedCostBasis) * 100.0
+                    : 0.0;
+            return new PortfolioListAdapter.RealizedGainLoss(realizedAmount, realizedPercent);
+        }
+
+        private List<TradeData> loadTrades(long stockId) {
+            List<TransactionLink> links = getStockLinks(linkRepo, stockId);
+            if (links == null || links.isEmpty()) {
+                return Collections.emptyList();
+            }
+
+            List<TradeData> trades = new ArrayList<>();
+            for (TransactionLink link : links) {
+                TradeData trade = createTrade(link);
+                if (trade != null) {
+                    trades.add(trade);
+                }
+            }
+            return trades;
+        }
+
+        private TradeData createTrade(TransactionLink link) {
+            if (link == null || link.getCheckingAccountId() == null) {
+                return null;
+            }
+
+            Long transactionId = link.getCheckingAccountId();
+            com.money.manager.ex.domainmodel.ShareInfo shareInfo = shareInfoRepo.loadByTransactionId(transactionId);
+            if (shareInfo == null) {
+                return null;
+            }
+
+            AccountTransaction tx = txRepo.load(transactionId);
+            Date txDate = tx != null ? tx.getDate() : null;
+
+            double shares = shareInfo.getShareNumber() != null ? shareInfo.getShareNumber() : 0.0;
+            double price = shareInfo.getSharePrice() != null ? shareInfo.getSharePrice() : 0.0;
+            double commission = shareInfo.getShareCommission() != null ? shareInfo.getShareCommission() : 0.0;
+            return new TradeData(transactionId, txDate, shares, price, commission);
+        }
+
+        private PortfolioListAdapter.RealizedGainLoss zeroResult() {
+            return new PortfolioListAdapter.RealizedGainLoss(MoneyFactory.fromDouble(0), 0.0);
+        }
+
+        private static final class Position {
+            private double heldShares;
+            private double heldCostBasis;
+
+            private void applyBuy(TradeData trade) {
+                heldShares += trade.shares;
+                heldCostBasis += (trade.shares * trade.price) + trade.commission;
+            }
+
+            private Result applySell(TradeData trade) {
+                double soldShares = Math.abs(trade.shares);
+                double sharesMatched = Math.min(soldShares, heldShares);
+                double averageCost = heldShares > 0.0 ? heldCostBasis / heldShares : 0.0;
+                double costRemoved = sharesMatched * averageCost;
+                double proceeds = (soldShares * trade.price) - trade.commission;
+
+                heldShares = Math.max(0.0, heldShares - sharesMatched);
+                heldCostBasis = Math.max(0.0, heldCostBasis - costRemoved);
+                if (heldShares == 0.0) {
+                    heldCostBasis = 0.0;
+                }
+
+                return new Result(proceeds - costRemoved, costRemoved);
+            }
+        }
+
+        private static final class Result {
+            private final double realizedAmount;
+            private final double realizedCostBasis;
+
+            private Result(double realizedAmount, double realizedCostBasis) {
+                this.realizedAmount = realizedAmount;
+                this.realizedCostBasis = realizedCostBasis;
+            }
         }
     }
 

--- a/app/src/main/java/com/money/manager/ex/investment/PortfolioFragment.java
+++ b/app/src/main/java/com/money/manager/ex/investment/PortfolioFragment.java
@@ -49,6 +49,7 @@ import com.money.manager.ex.datalayer.StockRepository;
 import com.money.manager.ex.datalayer.TaglinkRepository;
 import com.money.manager.ex.datalayer.TransactionLinkRepository;
 import com.money.manager.ex.database.ISplitTransaction;
+import com.money.manager.ex.domainmodel.AccountTransaction;
 import com.money.manager.ex.domainmodel.Account;
 import com.money.manager.ex.domainmodel.Stock;
 import com.money.manager.ex.domainmodel.StockHistory;
@@ -73,7 +74,13 @@ import androidx.recyclerview.widget.RecyclerView;
 import androidx.preference.PreferenceManager;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
 
 import com.mikepenz.fontawesome_typeface_library.FontAwesome;
 
@@ -509,6 +516,7 @@ public class PortfolioFragment extends BaseRecyclerFragment {
     private void updateDisplayedStocks() {
         if (mStocks == null) {
             mDisplayedStocks = null;
+            mAdapter.setRealizedGainLossByStockId(Collections.emptyMap());
             mAdapter.submitList(null);
             return;
         }
@@ -526,7 +534,99 @@ public class PortfolioFragment extends BaseRecyclerFragment {
             mDisplayedStocks = mStocks;
         }
 
+        mAdapter.setRealizedGainLossByStockId(calculateRealizedGainLossByStockId(mDisplayedStocks));
+
         mAdapter.submitList(new java.util.ArrayList<>(mDisplayedStocks), mAdapter::notifyDataSetChanged);
+    }
+
+    private Map<Long, PortfolioListAdapter.RealizedGainLoss> calculateRealizedGainLossByStockId(List<Stock> stocks) {
+        Map<Long, PortfolioListAdapter.RealizedGainLoss> result = new HashMap<>();
+        if (stocks == null || stocks.isEmpty()) {
+            return result;
+        }
+
+        TransactionLinkRepository linkRepo = new TransactionLinkRepository(requireContext());
+        ShareInfoRepository shareInfoRepo = new ShareInfoRepository(requireContext());
+        AccountTransactionRepository txRepo = new AccountTransactionRepository(requireContext());
+
+        for (Stock stock : stocks) {
+            if (stock == null || stock.getId() == null) continue;
+            result.put(stock.getId(), calculateRealizedGainLoss(stock.getId(), linkRepo, shareInfoRepo, txRepo));
+        }
+
+        return result;
+    }
+
+    private PortfolioListAdapter.RealizedGainLoss calculateRealizedGainLoss(
+            long stockId,
+            TransactionLinkRepository linkRepo,
+            ShareInfoRepository shareInfoRepo,
+            AccountTransactionRepository txRepo) {
+        List<TransactionLink> links = getStockLinks(linkRepo, stockId);
+        if (links == null || links.isEmpty()) {
+            return new PortfolioListAdapter.RealizedGainLoss(MoneyFactory.fromDouble(0), 0.0);
+        }
+
+        List<TradeData> trades = new ArrayList<>();
+        for (TransactionLink link : links) {
+            if (link == null || link.getCheckingAccountId() == null) continue;
+
+            Long transactionId = link.getCheckingAccountId();
+            com.money.manager.ex.domainmodel.ShareInfo shareInfo = shareInfoRepo.loadByTransactionId(transactionId);
+            if (shareInfo == null) continue;
+
+            AccountTransaction tx = txRepo.load(transactionId);
+            Date txDate = tx != null ? tx.getDate() : null;
+
+            double shares = shareInfo.getShareNumber() != null ? shareInfo.getShareNumber() : 0.0;
+            double price = shareInfo.getSharePrice() != null ? shareInfo.getSharePrice() : 0.0;
+            double commission = shareInfo.getShareCommission() != null ? shareInfo.getShareCommission() : 0.0;
+            trades.add(new TradeData(transactionId, txDate, shares, price, commission));
+        }
+
+        trades.sort(Comparator
+                .comparing((TradeData t) -> t.date, Comparator.nullsLast(Date::compareTo))
+                .thenComparingLong(t -> t.transactionId));
+
+        double heldShares = 0.0;
+        double heldCostBasis = 0.0;
+        double realizedAmount = 0.0;
+        double realizedCostBasis = 0.0;
+
+        for (TradeData trade : trades) {
+            if (trade.shares > 0) {
+                heldShares += trade.shares;
+                heldCostBasis += (trade.shares * trade.price) + trade.commission;
+                continue;
+            }
+
+            if (trade.shares >= 0) {
+                continue;
+            }
+
+            double soldShares = Math.abs(trade.shares);
+            double proceeds = (soldShares * trade.price) - trade.commission;
+            double averageCost = heldShares > 0 ? (heldCostBasis / heldShares) : 0.0;
+            double sharesMatched = Math.min(soldShares, Math.max(0.0, heldShares));
+            double costRemoved = sharesMatched * averageCost;
+
+            realizedAmount += proceeds - costRemoved;
+            realizedCostBasis += costRemoved;
+
+            heldShares = Math.max(0.0, heldShares - sharesMatched);
+            heldCostBasis = Math.max(0.0, heldCostBasis - costRemoved);
+            if (heldShares == 0.0) {
+                heldCostBasis = 0.0;
+            }
+        }
+
+        double realizedPercent = realizedCostBasis > 0
+                ? (realizedAmount / realizedCostBasis) * 100.0
+                : 0.0;
+
+        return new PortfolioListAdapter.RealizedGainLoss(
+                MoneyFactory.fromDouble(realizedAmount),
+                realizedPercent);
     }
 
     private boolean isHideZeroSharesEnabled() {
@@ -667,6 +767,23 @@ public class PortfolioFragment extends BaseRecyclerFragment {
             this.marketValue = marketValue;
             this.invested = invested;
             this.gainLoss = gainLoss;
+        }
+    }
+
+    private static final class TradeData {
+        private final long transactionId;
+        private final Date date;
+        private final double shares;
+        private final double price;
+        private final double commission;
+
+        private TradeData(long transactionId, Date date, double shares,
+                          double price, double commission) {
+            this.transactionId = transactionId;
+            this.date = date;
+            this.shares = shares;
+            this.price = price;
+            this.commission = commission;
         }
     }
 

--- a/app/src/main/java/com/money/manager/ex/investment/PortfolioListAdapter.java
+++ b/app/src/main/java/com/money/manager/ex/investment/PortfolioListAdapter.java
@@ -34,9 +34,12 @@ import com.money.manager.ex.currency.CurrencyService;
 import com.money.manager.ex.domainmodel.Account;
 import com.money.manager.ex.domainmodel.Stock;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import info.javaperformance.money.Money;
+import info.javaperformance.money.MoneyFactory;
 
 public class PortfolioListAdapter extends ListAdapter<Stock, PortfolioListAdapter.ViewHolder> {
     private final LayoutInflater inflater;
@@ -44,6 +47,7 @@ public class PortfolioListAdapter extends ListAdapter<Stock, PortfolioListAdapte
     private OnItemLongClickListener longClickListener;
     private Account mAccount;
     private final CurrencyService mCurrencyService;
+    private final Map<Long, RealizedGainLoss> mRealizedGainLossByStockId = new HashMap<>();
 
     public interface OnItemClickListener {
         void onItemClick(long stockId);
@@ -82,6 +86,11 @@ public class PortfolioListAdapter extends ListAdapter<Stock, PortfolioListAdapte
         this.longClickListener = listener;
     }
 
+    public void setRealizedGainLossByStockId(@NonNull Map<Long, RealizedGainLoss> gainLossByStockId) {
+        mRealizedGainLossByStockId.clear();
+        mRealizedGainLossByStockId.putAll(gainLossByStockId);
+    }
+
     @NonNull
     @Override
     public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
@@ -113,6 +122,15 @@ public class PortfolioListAdapter extends ListAdapter<Stock, PortfolioListAdapte
         holder.unrealizedGLAmountTextView.setText(mAccount == null ? "<unknown>" : mCurrencyService.getCurrencyFormatted(mAccount.getCurrencyId(), unrealizedAmount));
         holder.unrealizedGLPercentTextView.setText(String.format("%.2f%%", unrealizedPercent));
 
+        // Column 5: Realized G/L
+        RealizedGainLoss realizedGainLoss = mRealizedGainLossByStockId.get(stock.getId());
+        Money realizedAmount = realizedGainLoss != null ? realizedGainLoss.amount : MoneyFactory.fromDouble(0);
+        double realizedPercent = realizedGainLoss != null ? realizedGainLoss.percent : 0.0;
+        holder.realizedGLAmountTextView.setText(mAccount == null
+            ? "<unknown>"
+            : mCurrencyService.getCurrencyFormatted(mAccount.getCurrencyId(), realizedAmount));
+        holder.realizedGLPercentTextView.setText(String.format("%.2f%%", realizedPercent));
+
         // Zebra striping
         int bgColor = (position % 2 == 0) ? android.R.color.darker_gray : android.R.color.white;
         int fgColor = (position % 2 == 0) ? android.R.color.white : android.R.color.black;
@@ -126,6 +144,16 @@ public class PortfolioListAdapter extends ListAdapter<Stock, PortfolioListAdapte
         }
         holder.unrealizedGLAmountTextView.setTextColor(gainLossColor);
         holder.unrealizedGLPercentTextView.setTextColor(gainLossColor);
+
+        int realizedGainLossColor = ContextCompat.getColor(holder.itemView.getContext(), fgColor);
+        if (realizedAmount.toDouble() < 0) {
+            realizedGainLossColor = ContextCompat.getColor(holder.itemView.getContext(), R.color.red);
+        } else if (realizedAmount.toDouble() > 0) {
+            realizedGainLossColor = ContextCompat.getColor(holder.itemView.getContext(), R.color.green);
+        }
+        holder.realizedGLAmountTextView.setTextColor(realizedGainLossColor);
+        holder.realizedGLPercentTextView.setTextColor(realizedGainLossColor);
+
         holder.marketValueTextView.setTextColor(ContextCompat.getColor(holder.itemView.getContext(), fgColor));
         holder.sharesTextView.setTextColor(ContextCompat.getColor(holder.itemView.getContext(), fgColor));
         holder.nameTextView.setTextColor(ContextCompat.getColor(holder.itemView.getContext(), fgColor));
@@ -160,6 +188,9 @@ public class PortfolioListAdapter extends ListAdapter<Stock, PortfolioListAdapte
         // Column 4
         TextView unrealizedGLAmountTextView;
         TextView unrealizedGLPercentTextView;
+        // Column 5
+        TextView realizedGLAmountTextView;
+        TextView realizedGLPercentTextView;
 
         public ViewHolder(View itemView) {
             super(itemView);
@@ -175,6 +206,9 @@ public class PortfolioListAdapter extends ListAdapter<Stock, PortfolioListAdapte
             // Column 4
             unrealizedGLAmountTextView = itemView.findViewById(R.id.unrealizedGLAmountTextView);
             unrealizedGLPercentTextView = itemView.findViewById(R.id.unrealizedGLPercentTextView);
+            // Column 5
+            realizedGLAmountTextView = itemView.findViewById(R.id.realizedGLAmountTextView);
+            realizedGLPercentTextView = itemView.findViewById(R.id.realizedGLPercentTextView);
 
             itemView.setOnClickListener(v -> {
                 int position = getBindingAdapterPosition();
@@ -192,6 +226,16 @@ public class PortfolioListAdapter extends ListAdapter<Stock, PortfolioListAdapte
                 }
                 return false;
             });
+        }
+    }
+
+    public static final class RealizedGainLoss {
+        public final Money amount;
+        public final double percent;
+
+        public RealizedGainLoss(@NonNull Money amount, double percent) {
+            this.amount = amount;
+            this.percent = percent;
         }
     }
 }

--- a/app/src/main/res/layout/fragment_portfolio.xml
+++ b/app/src/main/res/layout/fragment_portfolio.xml
@@ -74,11 +74,147 @@
                 android:layout_height="match_parent"
                 android:scrollbars="none">
 
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/recyclerView"
+                <LinearLayout
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent"
-                    android:drawSelectorOnTop="false" />
+                    android:orientation="vertical">
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:background="@color/md_primary_dark"
+                        android:paddingTop="4dp"
+                        android:paddingBottom="4dp">
+
+                        <LinearLayout
+                            android:layout_width="100dp"
+                            android:layout_height="wrap_content"
+                            android:orientation="vertical"
+                            android:paddingStart="@dimen/mmx_margin"
+                            android:paddingEnd="8dp">
+
+                            <com.money.manager.ex.view.RobotoTextView
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:text="@string/name"
+                                android:textColor="@android:color/white"
+                                android:textSize="12sp" />
+
+                            <com.money.manager.ex.view.RobotoTextView
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:text="@string/symbol"
+                                android:textColor="@android:color/white"
+                                android:textSize="11sp" />
+                        </LinearLayout>
+
+                        <LinearLayout
+                            android:layout_width="120dp"
+                            android:layout_height="wrap_content"
+                            android:orientation="vertical"
+                            android:gravity="end"
+                            android:paddingHorizontal="8dp">
+
+                            <com.money.manager.ex.view.RobotoTextView
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:gravity="end"
+                                android:text="@string/market_value"
+                                android:textColor="@android:color/white"
+                                android:textSize="12sp" />
+
+                            <com.money.manager.ex.view.RobotoTextView
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:gravity="end"
+                                android:text="@string/shares"
+                                android:textColor="@android:color/white"
+                                android:textSize="11sp" />
+                        </LinearLayout>
+
+                        <LinearLayout
+                            android:layout_width="120dp"
+                            android:layout_height="wrap_content"
+                            android:orientation="vertical"
+                            android:gravity="end"
+                            android:paddingHorizontal="8dp">
+
+                            <com.money.manager.ex.view.RobotoTextView
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:gravity="end"
+                                android:text="@string/current_price"
+                                android:textColor="@android:color/white"
+                                android:textSize="12sp" />
+
+                            <com.money.manager.ex.view.RobotoTextView
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:gravity="end"
+                                android:text="@string/purchase_price"
+                                android:textColor="@android:color/white"
+                                android:textSize="11sp" />
+                        </LinearLayout>
+
+                        <LinearLayout
+                            android:layout_width="120dp"
+                            android:layout_height="wrap_content"
+                            android:orientation="vertical"
+                            android:gravity="end"
+                            android:paddingHorizontal="8dp">
+
+                            <com.money.manager.ex.view.RobotoTextView
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:gravity="end"
+                                android:text="@string/unrealized_gain_loss"
+                                android:textColor="@android:color/white"
+                                android:textSize="12sp" />
+
+                            <com.money.manager.ex.view.RobotoTextView
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:gravity="end"
+                                android:text="@string/percentage"
+                                android:textColor="@android:color/white"
+                                android:textSize="11sp" />
+                        </LinearLayout>
+
+                        <LinearLayout
+                            android:layout_width="120dp"
+                            android:layout_height="wrap_content"
+                            android:orientation="vertical"
+                            android:gravity="end"
+                            android:paddingHorizontal="8dp">
+
+                            <com.money.manager.ex.view.RobotoTextView
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:gravity="end"
+                                android:text="@string/realized_gain_loss"
+                                android:textColor="@android:color/white"
+                                android:textSize="12sp" />
+
+                            <com.money.manager.ex.view.RobotoTextView
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:gravity="end"
+                                android:text="@string/percentage"
+                                android:textColor="@android:color/white"
+                                android:textSize="11sp" />
+                        </LinearLayout>
+
+                    </LinearLayout>
+
+                    <androidx.recyclerview.widget.RecyclerView
+                        android:id="@+id/recyclerView"
+                        android:layout_width="wrap_content"
+                        android:layout_height="0dp"
+                        android:layout_weight="1"
+                        android:drawSelectorOnTop="false" />
+
+                </LinearLayout>
 
             </HorizontalScrollView>
 

--- a/app/src/main/res/layout/item_portfolio.xml
+++ b/app/src/main/res/layout/item_portfolio.xml
@@ -128,4 +128,30 @@
                             android:textSize="12sp"
                             android:paddingVertical="2dp"/>
                 </LinearLayout>
+
+                <!-- Column 5: Realized G/L | % -->
+                <LinearLayout
+                    android:layout_width="120dp"
+                    android:layout_height="match_parent"
+                    android:orientation="vertical"
+                    android:gravity="end"
+                    android:paddingHorizontal="8dp">
+
+                        <com.money.manager.ex.view.RobotoTextView
+                            android:id="@+id/realizedGLAmountTextView"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:gravity="end"
+                            android:textSize="14sp"
+                            android:paddingVertical="2dp"/>
+
+                        <com.money.manager.ex.view.RobotoTextView
+                            android:id="@+id/realizedGLPercentTextView"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:textColor="?android:attr/textColorSecondary"
+                            android:gravity="end"
+                            android:textSize="12sp"
+                            android:paddingVertical="2dp"/>
+                </LinearLayout>
         </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,6 +100,9 @@
     <string name="market_value">Market Value</string>
     <string name="invested">Invested</string>
     <string name="gain_loss">Gain / Loss</string>
+    <string name="unrealized_gain_loss">Unrealized G/L</string>
+    <string name="realized_gain_loss">Realized G/L</string>
+    <string name="percentage">%</string>
     <string name="delete_account">Delete Account</string>
     <string name="delete_stock_investment">Delete Stock Investment</string>
     <string name="account_name">Account name</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,7 +102,7 @@
     <string name="gain_loss">Gain / Loss</string>
     <string name="unrealized_gain_loss">Unrealized G/L</string>
     <string name="realized_gain_loss">Realized G/L</string>
-    <string name="percentage">%</string>
+    <string name="percentage" translatable="false">%</string>
     <string name="delete_account">Delete Account</string>
     <string name="delete_stock_investment">Delete Stock Investment</string>
     <string name="account_name">Account name</string>


### PR DESCRIPTION
This adds the realized gain and loss in the table of the portfolio (as it is also available in the desktop version) and adds a header explaining, what the numbers in the portfolio mean.