### PR TITLE
Add "Other" slice to pie chart

### DIFF
--- a/app/src/main/java/com/money/manager/ex/reports/PieChartFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/PieChartFragment.java
@@ -43,6 +43,8 @@ import com.github.mikephil.charting.highlight.Highlight;
 import com.github.mikephil.charting.listener.OnChartValueSelectedListener;
 import com.money.manager.ex.R;
 import com.money.manager.ex.core.UIHelper;
+import com.money.manager.ex.currency.CurrencyService;
+import info.javaperformance.money.MoneyFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -91,13 +93,51 @@ public class PieChartFragment
         ArrayList<Entry> yVals1 = new ArrayList<>();
         ArrayList<String> xVals = new ArrayList<>();
 
-        long length = mPieCharts.size() < MAX_NUM_ITEMS ? mPieCharts.size() : MAX_NUM_ITEMS;
-
-        for (int i = 0; i < length; i++) {
-            Entry e = new Entry((float) mPieCharts.get(i).getValue(), i);
-            yVals1.add(e);
-            xVals.add(mPieCharts.get(i).getText());
+        // compute total of all slices so percentages can be relative to the whole
+        double totalSum = 0d;
+        for (ValuePieEntry v : mPieCharts) {
+            totalSum += Math.abs(v.getValue());
         }
+
+        // decide how many top items to show; optionally add an "Other" slice appended last
+        boolean addOther = mPieCharts.size() > MAX_NUM_ITEMS;
+        int topCount;
+        if (addOther) {
+            topCount = MAX_NUM_ITEMS - 1; // reserve one slot for "Other"
+        } else {
+            topCount = mPieCharts.size();
+        }
+
+        ArrayList<ValuePieEntry> displayPieCharts = new ArrayList<>();
+        double sumShown = 0d;
+        for (int i = 0; i < topCount; i++) {
+            ValuePieEntry v = mPieCharts.get(i);
+            Entry e = new Entry((float) v.getValue(), yVals1.size());
+            yVals1.add(e);
+            xVals.add(v.getText());
+            displayPieCharts.add(v);
+            sumShown += Math.abs(v.getValue());
+        }
+
+        if (addOther) {
+            // compute Other = remainder (may be 0)
+            double otherValue = totalSum - sumShown;
+            ValuePieEntry otherItem = new ValuePieEntry(getString(R.string.pie_other), otherValue);
+            // try to produce a formatted value for the Other slice if possible
+            try {
+                CurrencyService currencyService = new CurrencyService(getActivity().getApplicationContext());
+                otherItem.setValueFormatted(currencyService.getBaseCurrencyFormatted(MoneyFactory.fromDouble(otherValue)));
+            } catch (Exception ex) {
+                // ignore formatting errors
+            }
+            Entry eOther = new Entry((float) otherValue, yVals1.size());
+            yVals1.add(eOther);
+            xVals.add(otherItem.getText());
+            displayPieCharts.add(otherItem);
+        }
+
+        // replace mPieCharts with the subset(+other) so selection maps correctly
+        mPieCharts = displayPieCharts;
 
         PieDataSet dataSet = new PieDataSet(yVals1, "");
         dataSet.setSliceSpace(3f);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -104,6 +104,7 @@
     <string name="unrealized_gain_loss">Unrealized G/L</string>
     <string name="realized_gain_loss">Realized G/L</string>
     <string name="percentage" translatable="false">%</string>
+    <string name="pie_other">Other</string>
     <string name="delete_account">Delete Account</string>
     <string name="delete_stock_investment">Delete Stock Investment</string>
     <string name="account_name">Account name</string>


### PR DESCRIPTION
When there are more than 12 slices in a pie chart of the categories or payee report, previously only the first 12 payees/categories were shown and the percentages were calculated with respect to the sum of the slices only instead of the whole sum. This could lead to confusion. With this PR, if there are too many slices, the last (12th) slice will be an aggregated "Other" slice accumulating all other payees or categories, such that the total sum in the pie chart is always the whole sum and therefore percentages are also computed correctly with respect to the total sum from the report. If there are no more than 12 slice, the behavior is as before.