### PR TITLE
Add option to disable grouping by accounts in search results

### DIFF
--- a/app/src/main/java/com/money/manager/ex/common/AllDataListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/common/AllDataListFragment.java
@@ -19,6 +19,7 @@ package com.money.manager.ex.common;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.ContentValues;
+import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
 import android.database.DatabaseUtils;
@@ -93,8 +94,8 @@ public class AllDataListFragment
     private static final String ARG_ACCOUNT_ID = "AccountId";
     private static final String ARG_SHOW_FLOATING_BUTTON = "ShowFloatingButton";
 
-    private final int SORT_BY_DATE_DESC = 0;
-    private final int SORT_BY_DATE_ASC = 1;
+    private static final int SORT_BY_DATE_DESC = 0;
+    private static final int SORT_BY_DATE_ASC = 1;
 
     public static AllDataListFragment newInstance(long accountId) {
         return newInstance(accountId, true);
@@ -424,14 +425,20 @@ public class AllDataListFragment
         Bundle latestArguments = getLatestArguments();
         if (latestArguments == null || !latestArguments.containsKey(KEY_ARGUMENTS_SORT)) return;
 
-        String sortDirection = (new AppSettings(getContext())).getTransactionSort() == SORT_BY_DATE_DESC
-                ? "DESC"
-                : "ASC";
-
-        String searchSort = QueryAllData.TOACCOUNTID + ", " + QueryAllData.Date + " " + sortDirection
-                + ", " + QueryAllData.TransactionType + ", " + QueryAllData.ID + " " + sortDirection;
-        latestArguments.putString(KEY_ARGUMENTS_SORT, searchSort);
+        latestArguments.putString(KEY_ARGUMENTS_SORT, getSearchResultsSortOrder(requireContext()));
         setLatestArguments(latestArguments);
+    }
+
+    public static String getSearchResultsSortOrder(@NonNull Context context) {
+        AppSettings settings = new AppSettings(context);
+        String sortDirection = settings.getTransactionSort() == SORT_BY_DATE_DESC ? "DESC" : "ASC";
+
+        if (settings.getSearchResultsGroupByAccount()) {
+            return QueryAllData.TOACCOUNTID + ", " + QueryAllData.Date + " " + sortDirection
+                    + ", " + QueryAllData.TransactionType + ", " + QueryAllData.ID + " " + sortDirection;
+        }
+
+        return QueryAllData.Date + " " + sortDirection + ", " + QueryAllData.ID + " " + sortDirection;
     }
 
     @Override

--- a/app/src/main/java/com/money/manager/ex/search/SearchActivity.java
+++ b/app/src/main/java/com/money/manager/ex/search/SearchActivity.java
@@ -30,7 +30,6 @@ import com.money.manager.ex.R;
 import com.money.manager.ex.common.AllDataListFragment;
 import com.money.manager.ex.common.MmxBaseFragmentActivity;
 import com.money.manager.ex.core.UIHelper;
-import com.money.manager.ex.database.QueryAllData;
 import com.money.manager.ex.settings.AppSettings;
 
 import org.parceler.Parcels;
@@ -183,6 +182,8 @@ public class SearchActivity
     }
 
     private void showSearchResultsFragment(String where) {
+        AppSettings settings = new AppSettings(this);
+
         //create a fragment for search results.
         AllDataListFragment searchResultsFragment = (AllDataListFragment) this.getSupportFragmentManager()
             .findFragmentByTag(AllDataListFragment.class.getSimpleName());
@@ -202,20 +203,17 @@ public class SearchActivity
 
 
         searchResultsFragment.showTotalsFooter();
+        this.ShowAccountHeaders = settings.getSearchResultsGroupByAccount();
 
         //create parameter bundle
         Bundle args = new Bundle();
         args.putString(AllDataListFragment.KEY_ARGUMENTS_WHERE, where);
 
         // Sorting
-        String sortDirection = (new AppSettings(this)).getTransactionSort() == 0 ? "DESC" : "ASC";
         args.putString(AllDataListFragment.KEY_ARGUMENTS_SORT,
-            QueryAllData.TOACCOUNTID + ", " + QueryAllData.Date + " " + sortDirection + ", " +
-                QueryAllData.TransactionType + ", " + QueryAllData.ID + " " + sortDirection);
+            AllDataListFragment.getSearchResultsSortOrder(this));
         //set arguments
         searchResultsFragment.getArguments().putAll(args);
-
-        this.ShowAccountHeaders = true;
 
         //add fragment
         FragmentTransaction transaction = this.getSupportFragmentManager().beginTransaction();

--- a/app/src/main/java/com/money/manager/ex/settings/AppSettings.java
+++ b/app/src/main/java/com/money/manager/ex/settings/AppSettings.java
@@ -121,6 +121,12 @@ public class AppSettings
     public int getTransactionSort() {return get("getTransactionSort", 0); }
     public void setTransactionSort(int value) { set("getTransactionSort", value); }
 
+    public boolean getSearchResultsGroupByAccount() {
+        return get(R.string.pref_search_results_group_by_account, true);
+    }
+
+    public void setSearchResultsGroupByAccount(boolean value) {
+        set(R.string.pref_search_results_group_by_account, value);
+    }
+
 }
-
-

--- a/app/src/main/res/values/prefids.xml
+++ b/app/src/main/res/values/prefids.xml
@@ -73,6 +73,7 @@
     <string name="pref_look_feel">preflookfeel</string>
     <string name="pref_security">prefsecurity</string>
     <string name="pref_database">prefdatabase</string>
+    <string name="pref_search_results_group_by_account">pref_search_results_group_by_account</string>
     <string name="pref_sort_payee">prefsortpayee</string>
     <string name="pref_show_tutorial">prefshowtutorial</string>
     <string name="pref_dashboard_group_visibility">pref-dashboard-group-visible</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -584,6 +584,8 @@
     <string name="pref_transaction_hide_reconciled_amounts_title">Hide Reconciled Amounts</string>
     <string name="pref_transaction_sort_by_type_summary">Arrange daily transactions by transaction type (deposit, transfer, withdrawal)</string>
     <string name="pref_transaction_sort_by_type_title">Sort Transactions by Type</string>
+    <string name="pref_search_results_group_by_account_title">Group Search Results by Account</string>
+    <string name="pref_search_results_group_by_account_summary">When enabled, search results are grouped by account. When disabled, all results are listed by date.</string>
     <string name="warning">Warning</string>
     <string name="no_transfer_splits">You have chosen to switch to Transfer but there are Split Categories on the transaction. Do you want to proceed and remove the Split Categories?</string>
     <string name="qif_export">Qif Export</string>

--- a/app/src/main/res/xml/preferences_behaviour.xml
+++ b/app/src/main/res/xml/preferences_behaviour.xml
@@ -63,6 +63,13 @@
 
     <SwitchPreference
         android:icon="@null"
+        android:defaultValue="true"
+        android:key="@string/pref_search_results_group_by_account"
+        android:summary="@string/pref_search_results_group_by_account_summary"
+        android:title="@string/pref_search_results_group_by_account_title" />
+
+    <SwitchPreference
+        android:icon="@null"
         android:defaultValue="false"
         android:key="@string/pref_sms_auto_trans"
         android:summary="@string/summary_sms_auto_trans"


### PR DESCRIPTION
This fixes #2934 by adding an option in the "Behavior" settings to disable the grouping by accounts in search results and instead only sort by date. By default it is turned on, which corresponds to the current behavior.