### PR TITLE
Fixed #2809: Implemented a "Hide/Show Balances" feature on the Home screen

### DIFF
--- a/app/src/main/java/com/money/manager/ex/home/HomeAccountsExpandableAdapter.java
+++ b/app/src/main/java/com/money/manager/ex/home/HomeAccountsExpandableAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 The Android Money Manager Ex Project Team
+ * Copyright (C) 2012-2025 The Android Money Manager Ex Project Team
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -57,18 +57,20 @@ public class HomeAccountsExpandableAdapter
     private HashMap<String, List<QueryAccountBills>> mAccountsByType = new HashMap<>();
     private HashMap<String, QueryAccountBills> mTotalsByType = new HashMap<>();
     private final boolean mHideReconciled;
+    private final boolean mHideBalances;
     private final CurrencyService mCurrencyService;
     private final HashMap<Long, InvestmentSummary> mInvestmentSummaries = new HashMap<>();
 
     public HomeAccountsExpandableAdapter(Context context, List<String> accountTypes,
                                          HashMap<String, List<QueryAccountBills>> accountsByType,
                                          HashMap<String, QueryAccountBills> totalsByType,
-                                         boolean hideReconciled) {
+                                         boolean hideReconciled, boolean hideBalances) {
         mContext = context;
         mAccountTypes = accountTypes;
         mAccountsByType = accountsByType;
         mTotalsByType = totalsByType;
         mHideReconciled = hideReconciled;
+        mHideBalances = hideBalances;
         mCurrencyService = new CurrencyService(mContext);
     }
 
@@ -164,22 +166,22 @@ public class HomeAccountsExpandableAdapter
             holder.imgAccountType.setImageDrawable(
                     uiHelper.getIcon(MMXIconFont.Icon.mmx_briefcase).sizeDp(iconSize).color(iconColor));
             holder.txtCashBalance.setTypeface(null, Typeface.BOLD);
-            holder.txtCashBalance.setText(mCurrencyService.getBaseCurrencyFormatted(summary.cashBalance));
+            holder.txtCashBalance.setText(mHideBalances ? "****" : mCurrencyService.getBaseCurrencyFormatted(summary.cashBalance));
             if (holder.txtReconciled != null) {
                 if (mHideReconciled) {
                     holder.txtReconciled.setVisibility(View.GONE);
                 } else {
                     holder.txtReconciled.setVisibility(View.VISIBLE);
                     holder.txtReconciled.setTypeface(null, Typeface.BOLD);
-                    holder.txtReconciled.setText(mCurrencyService.getBaseCurrencyFormatted(summary.reconciledCash));
+                    holder.txtReconciled.setText(mHideBalances ? "****" : mCurrencyService.getBaseCurrencyFormatted(summary.reconciledCash));
                 }
             }
             holder.txtMarketValue.setTypeface(null, Typeface.BOLD);
-            holder.txtMarketValue.setText(mCurrencyService.getBaseCurrencyFormatted(summary.marketValue));
+            holder.txtMarketValue.setText(mHideBalances ? "****" : mCurrencyService.getBaseCurrencyFormatted(summary.marketValue));
             holder.txtInvested.setTypeface(null, Typeface.BOLD);
-            holder.txtInvested.setText(mCurrencyService.getBaseCurrencyFormatted(summary.invested));
+            holder.txtInvested.setText(mHideBalances ? "****" : mCurrencyService.getBaseCurrencyFormatted(summary.invested));
             holder.txtGainLoss.setTypeface(null, Typeface.BOLD);
-            holder.txtGainLoss.setText(formatGainLoss(summary.gainLoss, summary.invested));
+            holder.txtGainLoss.setText(mHideBalances ? "****" : formatGainLoss(summary.gainLoss, summary.invested));
             int gainLossColor = summary.gainLoss.toDouble() < 0
                     ? ContextCompat.getColor(mContext, R.color.red)
                     : ContextCompat.getColor(mContext, R.color.green);
@@ -187,10 +189,10 @@ public class HomeAccountsExpandableAdapter
         } else {
             QueryAccountBills total = mTotalsByType.get(accountType);
             if (total != null) {
-                String totalDisplay = mCurrencyService.getBaseCurrencyFormatted(MoneyFactory.fromDouble(total.getTotalBaseConvRate()));
+                String totalDisplay = mHideBalances ? "****" : mCurrencyService.getBaseCurrencyFormatted(MoneyFactory.fromDouble(total.getTotalBaseConvRate()));
                 holder.txtAccountTotal.setText(totalDisplay);
                 if (!mHideReconciled) {
-                    String reconciledDisplay = mCurrencyService.getBaseCurrencyFormatted(MoneyFactory.fromDouble(total.getReconciledBaseConvRate()));
+                    String reconciledDisplay = mHideBalances ? "****" : mCurrencyService.getBaseCurrencyFormatted(MoneyFactory.fromDouble(total.getReconciledBaseConvRate()));
                     holder.txtAccountReconciled.setText(reconciledDisplay);
                 }
                 holder.txtAccountName.setText(total.getAccountName());
@@ -331,27 +333,27 @@ public class HomeAccountsExpandableAdapter
             }
             if (holder.txtCashBalance != null) {
                 holder.txtCashBalance.setTypeface(null, Typeface.NORMAL);
-                holder.txtCashBalance.setText(mCurrencyService.getBaseCurrencyFormatted(summary.cashBalance));
+                holder.txtCashBalance.setText(mHideBalances ? "****" : mCurrencyService.getBaseCurrencyFormatted(summary.cashBalance));
             }
             if (holder.txtReconciled != null) {
                 if (mHideReconciled) {
                     holder.txtReconciled.setVisibility(View.GONE);
                 } else {
                     holder.txtReconciled.setVisibility(View.VISIBLE);
-                    holder.txtReconciled.setText(mCurrencyService.getBaseCurrencyFormatted(summary.reconciledCash));
+                    holder.txtReconciled.setText(mHideBalances ? "****" : mCurrencyService.getBaseCurrencyFormatted(summary.reconciledCash));
                 }
             }
             if (holder.txtMarketValue != null) {
                 holder.txtMarketValue.setTypeface(null, Typeface.NORMAL);
-                holder.txtMarketValue.setText(mCurrencyService.getBaseCurrencyFormatted(summary.marketValue));
+                holder.txtMarketValue.setText(mHideBalances ? "****" : mCurrencyService.getBaseCurrencyFormatted(summary.marketValue));
             }
             if (holder.txtInvested != null) {
                 holder.txtInvested.setTypeface(null, Typeface.NORMAL);
-                holder.txtInvested.setText(mCurrencyService.getBaseCurrencyFormatted(summary.invested));
+                holder.txtInvested.setText(mHideBalances ? "****" : mCurrencyService.getBaseCurrencyFormatted(summary.invested));
             }
             if (holder.txtGainLoss != null) {
                 holder.txtGainLoss.setTypeface(null, Typeface.NORMAL);
-                holder.txtGainLoss.setText(formatGainLoss(summary.gainLoss, summary.invested));
+                holder.txtGainLoss.setText(mHideBalances ? "****" : formatGainLoss(summary.gainLoss, summary.invested));
                 int gainLossColor = summary.gainLoss.toDouble() < 0
                         ? ContextCompat.getColor(mContext, R.color.red)
                         : ContextCompat.getColor(mContext, R.color.green);
@@ -359,7 +361,7 @@ public class HomeAccountsExpandableAdapter
             }
         } else {
             // import formatted
-            String value = mCurrencyService.getCurrencyFormatted(account.getCurrencyId(), MoneyFactory.fromDouble(account.getTotal()));
+            String value = mHideBalances ? "****" : mCurrencyService.getCurrencyFormatted(account.getCurrencyId(), MoneyFactory.fromDouble(account.getTotal()));
             // set amount value
             holder.txtAccountTotal.setText(value);
 
@@ -367,7 +369,7 @@ public class HomeAccountsExpandableAdapter
             if(mHideReconciled) {
                 holder.txtAccountReconciled.setVisibility(View.GONE);
             } else {
-                value = mCurrencyService.getCurrencyFormatted(account.getCurrencyId(), MoneyFactory.fromDouble(account.getReconciled()));
+                value = mHideBalances ? "****" : mCurrencyService.getCurrencyFormatted(account.getCurrencyId(), MoneyFactory.fromDouble(account.getReconciled()));
                 holder.txtAccountReconciled.setText(value);
             }
         }

--- a/app/src/main/java/com/money/manager/ex/home/HomeFragment.java
+++ b/app/src/main/java/com/money/manager/ex/home/HomeFragment.java
@@ -50,6 +50,7 @@ import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
 
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
+import com.mikepenz.google_material_typeface_library.GoogleMaterial;
 import com.money.manager.ex.Constants;
 import com.money.manager.ex.MmexApplication;
 import com.money.manager.ex.R;
@@ -62,6 +63,7 @@ import com.money.manager.ex.common.events.AmountEnteredEvent;
 import com.money.manager.ex.core.ContextMenuIds;
 import com.money.manager.ex.core.InfoKeys;
 import com.money.manager.ex.core.TransactionTypes;
+import com.money.manager.ex.core.UIHelper;
 import com.money.manager.ex.core.database.DatabaseManager;
 import com.money.manager.ex.currency.CurrencyService;
 import com.money.manager.ex.database.QueryAccountBills;
@@ -178,6 +180,9 @@ public class HomeFragment
 
                 MenuItem hideBalancesItem = menu.findItem(R.id.menu_hide_balances);
                 if (hideBalancesItem != null) {
+                    UIHelper uiHelper = new UIHelper(getActivity());
+                    hideBalancesItem.setIcon(uiHelper.getIcon(mHideBalances ?
+                            GoogleMaterial.Icon.gmd_visibility_off : GoogleMaterial.Icon.gmd_visibility));
                     hideBalancesItem.setTitle(mHideBalances ? R.string.show_balances : R.string.hide_balances);
                 }
             }
@@ -410,7 +415,12 @@ public class HomeFragment
         } else if (item.getItemId() == R.id.menu_hide_balances) {
             mHideBalances = !mHideBalances;
             new AppSettings(getActivity()).getLookAndFeelSettings().setHideBalances(mHideBalances);
+
+            UIHelper uiHelper = new UIHelper(getActivity());
+            item.setIcon(uiHelper.getIcon(mHideBalances ?
+                    GoogleMaterial.Icon.gmd_visibility_off : GoogleMaterial.Icon.gmd_visibility));
             item.setTitle(mHideBalances ? R.string.show_balances : R.string.hide_balances);
+
             // Refresh the loaders to update the UI
             startLoaders();
             return true;

--- a/app/src/main/java/com/money/manager/ex/home/HomeFragment.java
+++ b/app/src/main/java/com/money/manager/ex/home/HomeFragment.java
@@ -126,6 +126,7 @@ public class HomeFragment
 
     private CurrencyService mCurrencyService;
     private boolean mHideReconciled;
+    private boolean mHideBalances;
 
     // This is the collapsible list of account groups with accounts.
     private ExpandableListView mExpandableListView;
@@ -174,6 +175,11 @@ public class HomeFragment
             @Override
             public void onCreateMenu(@NonNull Menu menu, @NonNull MenuInflater menuInflater) {
                 old_onCreateOptionsMenu(menu, menuInflater);
+
+                MenuItem hideBalancesItem = menu.findItem(R.id.menu_hide_balances);
+                if (hideBalancesItem != null) {
+                    hideBalancesItem.setTitle(mHideBalances ? R.string.show_balances : R.string.hide_balances);
+                }
             }
 
             @Override
@@ -320,7 +326,7 @@ public class HomeFragment
     @Override
     public void onLoaderReset(Loader<Cursor> loader) {
         if (loader.getId() == LOADER_ACCOUNT_BILLS) {
-            txtTotalAccounts.setText(mCurrencyService.getBaseCurrencyFormatted(MoneyFactory.fromString("0")));
+            txtTotalAccounts.setText(mHideBalances ? "****" : mCurrencyService.getBaseCurrencyFormatted(MoneyFactory.fromString("0")));
             setListViewAccountBillsVisible(false);
             mAccountsByType.clear();
             mTotalsByType.clear();
@@ -355,13 +361,13 @@ public class HomeFragment
                 TextView txtDifference = getActivity().findViewById(R.id.textViewDifference);
                 // set value
                 if (txtIncome != null)
-                    txtIncome.setText(mCurrencyService.getCurrencyFormatted(mCurrencyService.getBaseCurrencyId(),
+                    txtIncome.setText(mHideBalances ? "****" : mCurrencyService.getCurrencyFormatted(mCurrencyService.getBaseCurrencyId(),
                             MoneyFactory.fromDouble(income)));
                 if (txtExpenses != null)
-                    txtExpenses.setText(mCurrencyService.getCurrencyFormatted(mCurrencyService.getBaseCurrencyId(),
+                    txtExpenses.setText(mHideBalances ? "****" : mCurrencyService.getCurrencyFormatted(mCurrencyService.getBaseCurrencyId(),
                             MoneyFactory.fromDouble(Math.abs(expenses))));
                 if (txtDifference != null)
-                    txtDifference.setText(mCurrencyService.getCurrencyFormatted(mCurrencyService.getBaseCurrencyId(),
+                    txtDifference.setText(mHideBalances ? "****" : mCurrencyService.getCurrencyFormatted(mCurrencyService.getBaseCurrencyId(),
                             MoneyFactory.fromDouble(income - Math.abs(expenses))));
                 // manage progressbar
                 final ProgressBar barIncome = getActivity().findViewById(R.id.progressBarIncome);
@@ -400,6 +406,13 @@ public class HomeFragment
 
         if (item.getItemId() == R.id.menu_search) {
             startActivity(new Intent(getActivity(), SearchActivity.class));
+            return true;
+        } else if (item.getItemId() == R.id.menu_hide_balances) {
+            mHideBalances = !mHideBalances;
+            new AppSettings(getActivity()).getLookAndFeelSettings().setHideBalances(mHideBalances);
+            item.setTitle(mHideBalances ? R.string.show_balances : R.string.hide_balances);
+            // Refresh the loaders to update the UI
+            startLoaders();
             return true;
         }
 
@@ -615,10 +628,10 @@ public class HomeFragment
         // remove footer
         mExpandableListView.removeFooterView(linearFooter);
         // set text
-        txtTotalAccounts.setText(mCurrencyService.getBaseCurrencyFormatted(MoneyFactory.fromDouble(curTotal)));
+        txtTotalAccounts.setText(mHideBalances ? "****" : mCurrencyService.getBaseCurrencyFormatted(MoneyFactory.fromDouble(curTotal)));
         txtFooterSummary.setText(txtTotalAccounts.getText());
         if(!mHideReconciled) {
-            txtFooterSummaryReconciled.setText(mCurrencyService.getBaseCurrencyFormatted(MoneyFactory.fromDouble(curReconciled)));
+            txtFooterSummaryReconciled.setText(mHideBalances ? "****" : mCurrencyService.getBaseCurrencyFormatted(MoneyFactory.fromDouble(curReconciled)));
         }
         // add footer
         mExpandableListView.addFooterView(linearFooter, null, false);
@@ -846,7 +859,7 @@ public class HomeFragment
 
         // create adapter
         HomeAccountsExpandableAdapter expandableAdapter = new HomeAccountsExpandableAdapter(getActivity(),
-                mAccountTypes, mAccountsByType, mTotalsByType, mHideReconciled);
+                mAccountTypes, mAccountsByType, mTotalsByType, mHideReconciled, mHideBalances);
         // set adapter and shown
         mExpandableListView.setAdapter(expandableAdapter);
 
@@ -924,6 +937,7 @@ public class HomeFragment
     private void refreshSettings() {
         AppSettings settings = new AppSettings(getActivity());
         mHideReconciled = settings.getLookAndFeelSettings().getHideReconciledAmounts();
+        mHideBalances = settings.getLookAndFeelSettings().getHideBalances();
 
         if (txtFooterSummaryReconciled != null) {
             txtFooterSummaryReconciled.setVisibility(mHideReconciled ? View.GONE : View.VISIBLE);

--- a/app/src/main/java/com/money/manager/ex/settings/LookAndFeelSettings.java
+++ b/app/src/main/java/com/money/manager/ex/settings/LookAndFeelSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 The Android Money Manager Ex Project Team
+ * Copyright (C) 2012-2025 The Android Money Manager Ex Project Team
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -50,6 +50,16 @@ public class LookAndFeelSettings
     public boolean getHideReconciledAmounts() {
         String key = getSettingsKey(R.string.pref_transaction_hide_reconciled_amounts);
         return getBooleanSetting(key, false);
+    }
+
+    public boolean getHideBalances() {
+        String key = getSettingsKey(R.string.pref_hide_balances);
+        return getBooleanSetting(key, false);
+    }
+
+    public void setHideBalances(boolean value) {
+        String key = getSettingsKey(R.string.pref_hide_balances);
+        set(key, value);
     }
 
     public DefinedDateRangeName getShowTransactions() {

--- a/app/src/main/java/com/money/manager/ex/settings/LookFeelPreferenceFragment.java
+++ b/app/src/main/java/com/money/manager/ex/settings/LookFeelPreferenceFragment.java
@@ -82,6 +82,17 @@ public class LookFeelPreferenceFragment
             });
         }
 
+        // Hide balances setting
+
+        final SwitchPreferenceCompat chkHideBalances = findPreference(getString(R.string.pref_hide_balances));
+        if (chkHideBalances != null) {
+            chkHideBalances.setOnPreferenceChangeListener((preference, newValue) -> {
+                settings.setHideBalances((Boolean) newValue);
+                MainActivity.setRestartActivity(true);
+                return true;
+            });
+        }
+
         // Hide reconciled amounts setting.
 
         final SwitchPreferenceCompat chkHideReconciled = findPreference(getString(

--- a/app/src/main/res/menu/home_menu.xml
+++ b/app/src/main/res/menu/home_menu.xml
@@ -24,6 +24,12 @@
         android:icon="?attr/ic_action_search"
         android:title="@string/search"
         app:showAsAction="ifRoom"/>
+
+    <item
+        android:id="@+id/menu_hide_balances"
+        android:title="@string/hide_balances"
+        app:showAsAction="ifRoom"/>
+
     <!-- Settings, should always be in the overflow -->
     <!--<item android:id="@+id/action_settings"-->
     <!--android:title="@string/action_settings"-->

--- a/app/src/main/res/menu/home_menu.xml
+++ b/app/src/main/res/menu/home_menu.xml
@@ -18,19 +18,20 @@
 
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
       xmlns:app="http://schemas.android.com/apk/res-auto">
+    <!-- Hide/Show balances toggle (Icon set programmatically in HomeFragment) -->
+	<item
+        android:id="@+id/menu_hide_balances"
+        android:title="@string/hide_balances"
+        app:showAsAction="always"/>
+
     <!-- Search, should appear as action button -->
-    <item
+	<item
         android:id="@+id/menu_search"
         android:icon="?attr/ic_action_search"
         android:title="@string/search"
         app:showAsAction="ifRoom"/>
-
-    <item
-        android:id="@+id/menu_hide_balances"
-        android:title="@string/hide_balances"
-        app:showAsAction="ifRoom"/>
-
-    <!-- Settings, should always be in the overflow -->
+		
+	<!-- Settings, should always be in the overflow -->
     <!--<item android:id="@+id/action_settings"-->
     <!--android:title="@string/action_settings"-->
     <!--app:showAsAction="never" />-->
@@ -39,4 +40,5 @@
         <!--android:icon="?attr/ic_action_dropbox"-->
         <!--android:title="@string/synchronize"-->
         <!--app:showAsAction="never" />-->
+
 </menu>

--- a/app/src/main/res/values/prefids.xml
+++ b/app/src/main/res/values/prefids.xml
@@ -62,6 +62,7 @@
     <string name="pref_version_date">versiondate</string>
     <string name="pref_sqlite_version">sqliteversion</string>
     <string name="pref_transaction_shown_balance">transactionshownbalance</string>
+    <string name="pref_hide_balances">pref_hide_balances</string>
     <string name="pref_transaction_hide_reconciled_amounts">pref_transaction_hide_reconciled_amounts</string>
     <string name="pref_application_font">prefapplicationfont</string>
     <string name="pref_application_font_size">prefapplicationfontsize</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -985,5 +985,6 @@
     <string name="sync_setup_complete">Sync Setup Complete!</string>
     <string name="sync_failed">"Sync failed: "</string>
     <string name="sync_your_data_with_pocketbase_cloud">Sync your data with PocketBase Cloud</string>
-
+    <string name="show_balances">Show Balances</string>
+    <string name="hide_balances">Hide Balances</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -985,6 +985,10 @@
     <string name="sync_setup_complete">Sync Setup Complete!</string>
     <string name="sync_failed">"Sync failed: "</string>
     <string name="sync_your_data_with_pocketbase_cloud">Sync your data with PocketBase Cloud</string>
+	
+	<!-- Show & Hide Balance -->
     <string name="show_balances">Show Balances</string>
     <string name="hide_balances">Hide Balances</string>
+	<string name="pref_hide_balances_title">Hide Balances</string>
+    <string name="pref_hide_balances_summary">Hide account balances on the main screens.</string>
 </resources>

--- a/app/src/main/res/xml/preferences_look_and_feel.xml
+++ b/app/src/main/res/xml/preferences_look_and_feel.xml
@@ -46,6 +46,13 @@
     <SwitchPreferenceCompat
         android:defaultValue="false"
         android:icon="@null"
+        android:key="@string/pref_hide_balances"
+        android:summary="@string/pref_hide_balances_summary"
+        android:title="@string/pref_hide_balances_title"/>
+
+    <SwitchPreferenceCompat
+        android:defaultValue="false"
+        android:icon="@null"
         android:key="@string/pref_transaction_hide_reconciled_amounts"
         android:summary="@string/pref_transaction_hide_reconciled_amounts_summary"
         android:title="@string/pref_transaction_hide_reconciled_amounts_title"/>


### PR DESCRIPTION
Implemented a "Hide/Show Balances" feature on the Home screen. This allows users to obscure their financial data with a single tap.
Here is a summary of the changes:
1. Preference Storage: Added pref_hide_balances to prefids.xml to persist the user's choice.
2. Settings Integration: Updated LookAndFeelSettings.java with helper methods to get and set the balance visibility state.
3. UI Strings: Added show_balances and hide_balances strings to strings.xml.
4. Home Menu: Added a new menu item in home_menu.xml that appears on the Home screen's toolbar.
5. Home Screen Logic: Updated HomeFragment.java to:
	◦ Initialize the visibility state from preferences.
	◦ Handle toggling the state via the toolbar menu item.
	◦ Update the menu item text (Show/Hide) and obscure the "Total Accounts" and "Income vs Expenses" summary widgets when hidden.
	◦ Trigger a reload of data to ensure the UI reflects the change immediately.
6. Adapter Obscuration: Updated HomeAccountsExpandableAdapter.java to replace account balances, market values, and totals with **** when the hide feature is active.