### PR TITLE
Fix #2954: Retain search field content

### DIFF
--- a/app/src/main/java/com/money/manager/ex/search/SearchParametersFragment.java
+++ b/app/src/main/java/com/money/manager/ex/search/SearchParametersFragment.java
@@ -285,36 +285,46 @@ public class SearchParametersFragment
 
         switch (requestCode) {
             case RequestCodes.PAYEE:
-                viewHolder.txtSelectPayee.setTag(data.getLongExtra(PayeeActivity.INTENT_RESULT_PAYEEID, Constants.NOT_SET));
-                viewHolder.txtSelectPayee.setText(data.getStringExtra(PayeeActivity.INTENT_RESULT_PAYEENAME));
+                long payeeId = data.getLongExtra(PayeeActivity.INTENT_RESULT_PAYEEID, Constants.NOT_SET);
+                String payeeName = data.getStringExtra(PayeeActivity.INTENT_RESULT_PAYEENAME);
+
+                searchParameters = collectSearchCriteria();
+                searchParameters.payeeId = (payeeId == Constants.NOT_SET) ? null : payeeId;
+                searchParameters.payeeName = payeeName;
+                setSearchParameters(searchParameters);
                 break;
             case RequestCodes.TAG:
-                viewHolder.txtSelectTag.setTag(data.getLongExtra(TagActivity.INTENT_RESULT_TAGID, Constants.NOT_SET));
-                viewHolder.txtSelectTag.setText(data.getStringExtra(TagActivity.INTENT_RESULT_TAGNAME));
+                long tagId = data.getLongExtra(TagActivity.INTENT_RESULT_TAGID, Constants.NOT_SET);
+                String tagName = data.getStringExtra(TagActivity.INTENT_RESULT_TAGNAME);
+
+                searchParameters = collectSearchCriteria();
+                searchParameters.tagId = (tagId == Constants.NOT_SET) ? null : tagId;
+                searchParameters.tagName = tagName;
+                setSearchParameters(searchParameters);
                 break;
             case RequestCodes.CATEGORY:
                 //create class for store data
                 CategorySub categorySub = new CategorySub();
                 categorySub.categId = data.getLongExtra(CategoryListActivity.INTENT_RESULT_CATEGID, Constants.NOT_SET);
                 categorySub.categName = data.getStringExtra(CategoryListActivity.INTENT_RESULT_CATEGNAME);
-                //update into button
-                displayCategory(categorySub);
+
+                searchParameters = collectSearchCriteria();
+                searchParameters.category = categorySub;
+                setSearchParameters(searchParameters);
                 break;
 
             case RequestCodes.AMOUNT_FROM:
                 stringExtra = data.getStringExtra(CalculatorActivity.RESULT_AMOUNT);
-                searchParameters = getSearchParameters();
+                searchParameters = collectSearchCriteria();
                 searchParameters.amountFrom = MoneyFactory.fromString(stringExtra);
                 setSearchParameters(searchParameters);
-                displayAmountFrom();
                 break;
 
             case RequestCodes.AMOUNT_TO:
                 stringExtra = data.getStringExtra(CalculatorActivity.RESULT_AMOUNT);
-                searchParameters = getSearchParameters();
+                searchParameters = collectSearchCriteria();
                 searchParameters.amountTo = MoneyFactory.fromString(stringExtra);
                 setSearchParameters(searchParameters);
-                displayAmountTo();
                 break;
         }
     }
@@ -395,12 +405,9 @@ public class SearchParametersFragment
                     public void onDateSet(DatePicker view, int year, int month, int dayOfMonth) {
                         MmxDate date = new MmxDate(year, month, dayOfMonth);
 
-                        SearchParameters parameters = getSearchParameters();
+                        SearchParameters parameters = collectSearchCriteria();
                         parameters.dateFrom = date.toDate();
                         setSearchParameters(parameters);
-
-                        String displayText = new MmxDateTimeUtils().getUserFormattedDate(getActivity(), date.toDate());
-                        viewHolder.txtDateFrom.setText(displayText);
                     }
                 },
                 currentValue.getYear(),
@@ -421,12 +428,9 @@ public class SearchParametersFragment
                     public void onDateSet(DatePicker view, int year, int month, int dayOfMonth) {
                         MmxDate date = new MmxDate(year, month, dayOfMonth);
 
-                        SearchParameters parameters = getSearchParameters();
+                        SearchParameters parameters = collectSearchCriteria();
                         parameters.dateTo = date.toDate();
                         setSearchParameters(parameters);
-
-                        String displayText = new MmxDateTimeUtils().getUserFormattedDate(getActivity(), date.toDate());
-                        viewHolder.txtDateTo.setText(displayText);
                     }
                 },
                 currentValue.getYear(),
@@ -615,15 +619,16 @@ public class SearchParametersFragment
         }
 
         SearchParameters searchParameters = getSearchParameters();
+        if (searchParameters == null) {
+            searchParameters = new SearchParameters();
+        }
 
         // Account
         if (this.spinAccount != null) {
             int selectedAccountPosition = spinAccount.getSelectedItemPosition();
             if (selectedAccountPosition != AdapterView.INVALID_POSITION) {
                 long selectedAccountId = mAccountIdList.get(selectedAccountPosition);
-                if (selectedAccountId != Constants.NOT_SET) {
-                    searchParameters.accountId = selectedAccountId;
-                }
+                searchParameters.accountId = (selectedAccountId == Constants.NOT_SET) ? null : selectedAccountId;
             }
         }
 
@@ -632,9 +637,7 @@ public class SearchParametersFragment
             int position = spinCurrency.getSelectedItemPosition();
             if (position != AdapterView.INVALID_POSITION) {
                 long currencyId = mCurrencyIdList.get(position);
-                if (currencyId != Constants.NOT_SET) {
-                    searchParameters.currencyId = currencyId;
-                }
+                searchParameters.currencyId = (currencyId == Constants.NOT_SET) ? null : currencyId;
             }
         }
 
@@ -644,7 +647,7 @@ public class SearchParametersFragment
         searchParameters.withdrawal = cbxWithdrawal.isChecked();
 
         // Status
-        if (spinStatus.getSelectedItemPosition() > 0) {
+        if (spinStatus != null && spinStatus.getSelectedItemPosition() >= 0) {
             searchParameters.status = mStatusValues.get(spinStatus.getSelectedItemPosition());
         }
 
@@ -652,11 +655,15 @@ public class SearchParametersFragment
         Object tag = viewHolder.txtAmountFrom.getTag();
         if (tag != null) {
             searchParameters.amountFrom = MoneyFactory.fromString((String) tag);
+        } else {
+            searchParameters.amountFrom = null;
         }
         // Amount to
         tag = viewHolder.txtAmountTo.getTag();
         if (tag != null) {
             searchParameters.amountTo = MoneyFactory.fromString((String) tag);
+        } else {
+            searchParameters.amountTo = null;
         }
 
 //        // Date from
@@ -668,28 +675,37 @@ public class SearchParametersFragment
 //            String dateString = viewHolder.txtDateTo.getTag().toString();
 //            searchParameters.dateTo = new MmxDate(dateString).toDate();
 //        }
+
         // Payee
         if (viewHolder.txtSelectPayee.getTag() != null) {
             searchParameters.payeeId = Long.parseLong(viewHolder.txtSelectPayee.getTag().toString());
             searchParameters.payeeName = viewHolder.txtSelectPayee.getText().toString();
+        } else {
+            searchParameters.payeeId = null;
+            searchParameters.payeeName = null;
         }
         // tag
         if (viewHolder.txtSelectTag.getTag() != null) {
             searchParameters.tagId = Long.parseLong(viewHolder.txtSelectTag.getTag().toString());
             searchParameters.tagName = viewHolder.txtSelectTag.getText().toString();
+        } else {
+            searchParameters.tagId = null;
+            searchParameters.tagName = null;
         }
         // Category
         if (txtSelectCategory.getTag() != null) {
-            searchParameters.category = (CategorySub) txtSelectCategory.getTag();
-            searchParameters.searchSubCategory = cbxSearchSubCategory.isChecked();
+        searchParameters.category = (CategorySub) txtSelectCategory.getTag();
+        searchParameters.searchSubCategory = cbxSearchSubCategory.isChecked();
         }
+
         // Transaction number
         if (!TextUtils.isEmpty(viewHolder.txtTransNumber.getText())) {
-            searchParameters.transactionNumber = viewHolder.txtTransNumber.getText().toString();
+        searchParameters.transactionNumber = viewHolder.txtTransNumber.getText().toString();
         }
+		
         // Notes
         if (!TextUtils.isEmpty(txtNotes.getText())) {
-            searchParameters.notes = txtNotes.getText().toString();
+        searchParameters.notes = txtNotes.getText().toString();
         }
 
         return searchParameters;
@@ -727,8 +743,20 @@ public class SearchParametersFragment
         SearchParameters searchParameters = getSearchParameters();
 
         // Account
-        this.spinAccount.setSelection(0);
-        this.spinCurrency.setSelection(0);
+        if (searchParameters.accountId != null) {
+            int index = mAccountIdList.indexOf(searchParameters.accountId);
+            this.spinAccount.setSelection(index >= 0 ? index : 0);
+        } else {
+            this.spinAccount.setSelection(0);
+        }
+
+        // Currency
+        if (searchParameters.currencyId != null) {
+            int index = mCurrencyIdList.indexOf(searchParameters.currencyId);
+            this.spinCurrency.setSelection(index >= 0 ? index : 0);
+        } else {
+            this.spinCurrency.setSelection(0);
+        }
 
         // Transaction Type
         viewHolder.cbxDeposit.setChecked(searchParameters.deposit);
@@ -736,7 +764,12 @@ public class SearchParametersFragment
         cbxWithdrawal.setChecked(searchParameters.withdrawal);
 
         // Status
-        this.spinStatus.setSelection(0);
+        if (searchParameters.status != null) {
+            int index = mStatusValues.indexOf(searchParameters.status);
+            this.spinStatus.setSelection(index >= 0 ? index : 0);
+        } else {
+            this.spinStatus.setSelection(0);
+        }
 
         // Amount from
         if (searchParameters.amountFrom != null) {
@@ -771,8 +804,8 @@ public class SearchParametersFragment
         viewHolder.txtSelectPayee.setText(searchParameters.payeeName);
         // Category
         displayCategory(searchParameters.category);
-        cbxSearchSubCategory.setEnabled(true);
-        cbxSearchSubCategory.setChecked(true);
+        cbxSearchSubCategory.setChecked(searchParameters.searchSubCategory);
+        cbxSearchSubCategory.setEnabled(searchParameters.category != null);
 
         // Transaction number
         viewHolder.txtTransNumber.setText(searchParameters.transactionNumber);


### PR DESCRIPTION
I have fixed the bug where search fields would reset themselves when interacting with other fields (like the Date picker or Payee selector).
The issue was caused by the fragment re-displaying search criteria from its stored "arguments" whenever a field was updated, without first saving the current state of other UI elements (like the selected Account). I have updated SearchParametersFragment.java to:

1. Collect current UI state before any operation that triggers a UI refresh (Date picking, Payee/Tag/Category selection, and Amount calculations).
2. Persist the collected state into the fragment's arguments so it's not lost when displaySearchCriteria() is called.
3. Fixed the "Search Subcategory" checkbox which was hardcoded to reset to "Checked" whenever the UI was refreshed.
4. Improved Spinner state restoration to ensure selected Account, Currency, and Status are correctly re-selected.

Specifically, I updated onActivityResult, onDateFromClicked, onDateToClicked, and the collectSearchCriteria/displaySearchCriteria methods to ensure consistent state management.