### PR TITLE
Fixed #2936 : Fixed the hardware back button was bypassing the "dirty" check

### DIFF
--- a/app/src/main/java/com/money/manager/ex/investment/InvestmentTransactionEditActivity.java
+++ b/app/src/main/java/com/money/manager/ex/investment/InvestmentTransactionEditActivity.java
@@ -316,7 +316,7 @@ public class InvestmentTransactionEditActivity
         // Handle action bar item clicks here. The action bar will
         // automatically e clicks on the Home/Up button, so long
         // as you specify a parent activity in AndroidManifest.xml.
-        int id = item.getItemId();
+        long id = item.getItemId();
 
         if (id == android.R.id.home) {
             return onActionCancelClick();

--- a/app/src/main/java/com/money/manager/ex/investment/InvestmentTransactionEditActivity.java
+++ b/app/src/main/java/com/money/manager/ex/investment/InvestmentTransactionEditActivity.java
@@ -316,13 +316,29 @@ public class InvestmentTransactionEditActivity
         // Handle action bar item clicks here. The action bar will
         // automatically e clicks on the Home/Up button, so long
         // as you specify a parent activity in AndroidManifest.xml.
-        long id = item.getItemId();
+        int id = item.getItemId();
 
-        if (id == MenuHelper.save) {
+        if (id == android.R.id.home) {
+            return onActionCancelClick();
+        } else if (id == MenuHelper.save) {
             return onActionDoneClick();
         }
 
         return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    public boolean onActionCancelClick() {
+        if (mCommon != null) {
+            return mCommon.onActionCancelClick();
+        }
+        finish();
+        return true;
+    }
+
+    @Override
+    public boolean onHandleOnBackPressed() {
+        return onActionCancelClick();
     }
 
     @Override
@@ -338,6 +354,9 @@ public class InvestmentTransactionEditActivity
     }
 
     public void setDirty(boolean dirty) {
+        if (mCommon != null) {
+            mCommon.setDirty(dirty);
+        }
     }
 
     private void onNumSharesClick() {

--- a/app/src/main/java/com/money/manager/ex/scheduled/ScheduledTransactionEditActivity.java
+++ b/app/src/main/java/com/money/manager/ex/scheduled/ScheduledTransactionEditActivity.java
@@ -217,7 +217,7 @@ public class ScheduledTransactionEditActivity
 
     @Override
     public boolean onHandleOnBackPressed() {
-        return !onActionCancelClick();
+        return onActionCancelClick();
     }
 
 //    @Override

--- a/app/src/main/java/com/money/manager/ex/transactions/CheckingTransactionEditActivity.java
+++ b/app/src/main/java/com/money/manager/ex/transactions/CheckingTransactionEditActivity.java
@@ -199,6 +199,11 @@ public class CheckingTransactionEditActivity
         }
     }
 
+    @Override
+    public boolean onHandleOnBackPressed() {
+        return onActionCancelClick();
+    }
+
     // Events
 
     @Subscribe


### PR DESCRIPTION
The bug occurred because the hardware back button was bypassing the "dirty" check (which detects unsaved changes). I have unified the behavior by overriding onHandleOnBackPressed in the transaction edit activities to call onActionCancelClick(). This method specifically checks if the user has modified any data and, if so, displays the "Discard changes" confirmation dialog shown in your screenshot.

Summary of the applied fix:

1. CheckingTransactionEditActivity.java: Added the onHandleOnBackPressed override to trigger the confirmation dialog when changes exist.
2. ScheduledTransactionEditActivity.java: Applied the same override to ensure recurring transaction edits also show the warning.
3. InvestmentTransactionEditActivity.java: Updated both the Home button and hardware back button logic to show the confirmation dialog if changes are detected.
4. These changes ensure that pressing the hardware back button now provides the same protection against accidental data loss as clicking the software back button (the arrow in the top-left toolbar).