### PR TITLE
Fix #2967

### DIFF
--- a/app/src/main/java/com/money/manager/ex/investment/PortfolioFragment.java
+++ b/app/src/main/java/com/money/manager/ex/investment/PortfolioFragment.java
@@ -767,10 +767,13 @@ public class PortfolioFragment extends BaseRecyclerFragment {
                 }
             }
 
-            double realizedPercent = realizedCostBasis > 0.0
+            // A percentage return is undefined without a realized cost basis (division
+            // by zero), so flag it as absent rather than reporting a misleading 0.00%.
+            boolean hasPercent = realizedCostBasis > 0.0;
+            double realizedPercent = hasPercent
                     ? (realizedAmount.toDouble() / realizedCostBasis) * 100.0
                     : 0.0;
-            return new PortfolioListAdapter.RealizedGainLoss(realizedAmount, realizedPercent);
+            return new PortfolioListAdapter.RealizedGainLoss(realizedAmount, realizedPercent, hasPercent);
         }
 
         private List<TradeData> loadTrades(long stockId) {
@@ -810,7 +813,7 @@ public class PortfolioFragment extends BaseRecyclerFragment {
         }
 
         private PortfolioListAdapter.RealizedGainLoss zeroResult() {
-            return new PortfolioListAdapter.RealizedGainLoss(MoneyFactory.fromDouble(0), 0.0);
+            return new PortfolioListAdapter.RealizedGainLoss(MoneyFactory.fromDouble(0), 0.0, false);
         }
 
         private static final class Position {

--- a/app/src/main/java/com/money/manager/ex/investment/PortfolioListAdapter.java
+++ b/app/src/main/java/com/money/manager/ex/investment/PortfolioListAdapter.java
@@ -117,19 +117,20 @@ public class PortfolioListAdapter extends ListAdapter<Stock, PortfolioListAdapte
 
         // Column 4: Unrealized G/L
         Money unrealizedAmount = calculateUnrealizedGainLoss(stock);
-        double unrealizedPercent = calculateUnrealizedPercentage(stock);
 
         holder.unrealizedGLAmountTextView.setText(mAccount == null ? "<unknown>" : mCurrencyService.getCurrencyFormatted(mAccount.getCurrencyId(), unrealizedAmount));
-        holder.unrealizedGLPercentTextView.setText(String.format("%.2f%%", unrealizedPercent));
+        holder.unrealizedGLPercentTextView.setText(formatUnrealizedPercentage(stock));
 
         // Column 5: Realized G/L
         RealizedGainLoss realizedGainLoss = mRealizedGainLossByStockId.get(stock.getId());
         Money realizedAmount = realizedGainLoss != null ? realizedGainLoss.amount : MoneyFactory.fromDouble(0);
-        double realizedPercent = realizedGainLoss != null ? realizedGainLoss.percent : 0.0;
         holder.realizedGLAmountTextView.setText(mAccount == null
             ? "<unknown>"
             : mCurrencyService.getCurrencyFormatted(mAccount.getCurrencyId(), realizedAmount));
-        holder.realizedGLPercentTextView.setText(String.format("%.2f%%", realizedPercent));
+        holder.realizedGLPercentTextView.setText(
+            realizedGainLoss != null && realizedGainLoss.hasPercent
+                ? String.format("%.2f%%", realizedGainLoss.percent)
+                : "");
 
         // Zebra striping
         int bgColor = (position % 2 == 0) ? android.R.color.darker_gray : android.R.color.white;
@@ -169,12 +170,15 @@ public class PortfolioListAdapter extends ListAdapter<Stock, PortfolioListAdapte
         return marketValue.subtract(costBasis);
     }
 
-    private double calculateUnrealizedPercentage(Stock stock) {
+    private String formatUnrealizedPercentage(Stock stock) {
         Money costBasis = stock.getValue();
-        if (costBasis.isZero()) return 0.0;
+        // A percentage return is undefined when there is no cost basis (division by
+        // zero), so omit it rather than showing a misleading 0.00%.
+        if (costBasis.isZero()) return "";
         Money marketValue = stock.getCurrentPrice().multiply(stock.getNumberOfShares());
         Money gainLoss = marketValue.subtract(costBasis);
-        return (gainLoss.toDouble() / costBasis.toDouble()) * 100.0;
+        double percent = (gainLoss.toDouble() / costBasis.toDouble()) * 100.0;
+        return String.format("%.2f%%", percent);
     }
 
     public class ViewHolder extends RecyclerView.ViewHolder {
@@ -234,10 +238,12 @@ public class PortfolioListAdapter extends ListAdapter<Stock, PortfolioListAdapte
     public static final class RealizedGainLoss {
         public final Money amount;
         public final double percent;
+        public final boolean hasPercent;
 
-        public RealizedGainLoss(@NonNull Money amount, double percent) {
+        public RealizedGainLoss(@NonNull Money amount, double percent, boolean hasPercent) {
             this.amount = amount;
             this.percent = percent;
+            this.hasPercent = hasPercent;
         }
     }
 }

--- a/app/src/main/java/com/money/manager/ex/reports/SummaryOfStocksReportFragment.java
+++ b/app/src/main/java/com/money/manager/ex/reports/SummaryOfStocksReportFragment.java
@@ -200,7 +200,10 @@ public class SummaryOfStocksReportFragment extends Fragment {
         Money marketValue = stock.getCurrentPrice().multiply(stock.getNumberOfShares());
         Money totalCost = realizedGainLoss.investedCost;
         Money commission = realizedGainLoss.totalCommission;
-        Money unrealizedGainLoss = realizedGainLoss.openCostBasis.toDouble() <= 0.0
+        // Only fully-closed positions (no shares held) have no unrealized gain/loss.
+        // A position with a zero cost basis but positive shares still has unrealized
+        // gain/loss equal to its market value, so guard on shares rather than cost basis.
+        Money unrealizedGainLoss = shares.toDouble() <= 0.0
             ? MoneyFactory.fromDouble(0)
             : marketValue.subtract(realizedGainLoss.openCostBasis);
 


### PR DESCRIPTION
This fixes the unrealized gain and loss in the summary of stocks for a zero purchase prize.
Regarding the percentage: When the purchase prize is zero the percentage does not make sense because it is relative to the purchase prize, i.e., we have to divide by it. If it is zero, we cannot divide by it. Therefore, with this PR the percentage is not shown (instead of shown as zero in the portfolio) for a purchase prize of zero in both the portfolio and the summary of stocks report.
Can you please test this, @velmuruganc?

Fixes #2967.