### PR TITLE
fix: crash on resume when restartLoader unregisters a destroyed loader in HomeFragment

### DIFF
--- a/app/src/main/java/com/money/manager/ex/home/HomeFragment.java
+++ b/app/src/main/java/com/money/manager/ex/home/HomeFragment.java
@@ -596,6 +596,10 @@ public class HomeFragment
     // Public
 
     public void startLoaders() {
+        if (!isAdded() || isStateSaved()) {
+            return;
+        }
+
         LoaderManager loaderManager = getLoaderManager();
 //        loaderManager.restartLoader(LOADER_USER_NAME, null, this);
         loadUsername();


### PR DESCRIPTION
## Summary

Fixes #2957: the app crashes on resume / device rotation (landscape) with `RuntimeException: Unable to resume activity ... IllegalStateException: No listener register`.

## Background

The stack trace points at `HomeFragment.startLoaders()` calling `LoaderManager.restartLoader(...)`. When `restartLoader` runs during a configuration-change / resume transition, androidx's `LoaderManager` can destroy the prior `LoaderInfo` and call `Loader.unregisterListener` on a loader that no longer has a registered listener, throwing `IllegalStateException: No listener register` and bringing down the resume path.

## Fix

Guard `startLoaders()` so the loader transaction only runs when the fragment is in a valid state for it. An early return when `!isAdded() || isStateSaved()` keeps the `restartLoader` calls from executing during the unsafe resume/state-saved window where the unregister race occurs. When the fragment becomes active again, the existing call sites (`onResume()` and the hide-balances menu action) refresh the loaders normally, so the refresh-on-resume behavior is preserved.

The change is confined to `HomeFragment.startLoaders()`; no public API, query logic, or other files are touched.

## Testing

- Open Home, rotate the device repeatedly: loaders refresh, no crash.
- Background the app, rotate while backgrounded, foreground again (resume after state-saved): `startLoaders()` no-ops safely instead of throwing.
