### PR TITLE
fix: budget Forecast Remain now accounts for recurring scheduled transactions

### DIFF
--- a/app/src/main/java/com/money/manager/ex/budget/BudgetAdapter.java
+++ b/app/src/main/java/com/money/manager/ex/budget/BudgetAdapter.java
@@ -328,7 +328,7 @@ public class BudgetAdapter
         if ( ! scheduledTransactionForecastListServices.isReady() ) return 0;
 
         // budget is based on year, Year financial, or monthly
-        MmxDate date = new MmxDate(getDateTo().toDate());
+        MmxDate date = new MmxDate(getDateFrom().toDate());
         Double total = 0.0;
         ScheduleTransactionForecastList list = scheduledTransactionForecastListServices.getRecurringTransactions();
         while (date.toDate().compareTo(getDateTo().toDate()) < 0) {


### PR DESCRIPTION
## Summary

- Fixed a one-line off-by-one bug in `BudgetAdapter.getEstimateFromRecurringTransaction()` where the loop variable was initialized to `getDateTo()` instead of `getDateFrom()`
- The `while (date < getDateTo())` loop condition was always false on entry, so no scheduled transactions were ever summed and Forecast Remain always equalled Available
- With this fix the loop now iterates from the budget start date through the end date, correctly accumulating `ScheduleTransactionForecastList.getForecastAmountFromCache()` for each month

## Why this matters

Closes #2942. Users who create recurring monthly scheduled expenses (e.g. Food:Groceries $1,000/month) saw zero effect on the Forecast Remain column in the Budgets screen. The column is now accurate.

## Testing

- Create a recurring monthly expense in a budget category; verify Forecast Remain = Available minus the scheduled amount
- Create recurring transactions spanning multiple months; verify each month's forecast is summed
- With no scheduled transactions, Forecast Remain should still equal Available (no regression)
- Scheduled transaction on the first day of the budget period should be included