### PR TITLE
Fix NullPointerException crash when exporting database with no current database

### DIFF
--- a/app/src/main/java/com/money/manager/ex/sync/SyncPreferenceFragment.java
+++ b/app/src/main/java/com/money/manager/ex/sync/SyncPreferenceFragment.java
@@ -143,6 +143,10 @@ public class SyncPreferenceFragment
 
         viewHolder.download.setOnPreferenceClickListener(preference -> {
             DatabaseMetadata currentDb = getDatabases().getCurrent();
+            if (currentDb == null) {
+                Toast.makeText(getContext(), R.string.remote_unavailable, Toast.LENGTH_SHORT).show();
+                return false;
+            }
 
             SyncManager sync = new SyncManager(getContext());
             if (sync.canSync()) {
@@ -161,6 +165,10 @@ public class SyncPreferenceFragment
 
         viewHolder.upload.setOnPreferenceClickListener(preference -> {
             DatabaseMetadata currentDb = getDatabases().getCurrent();
+            if (currentDb == null) {
+                Toast.makeText(getContext(), R.string.remote_unavailable, Toast.LENGTH_SHORT).show();
+                return false;
+            }
 
             SyncManager sync = new SyncManager(getContext());
             if (sync.canSync()) {


### PR DESCRIPTION
## Summary

Tapping "Export Database" (upload) in Settings -> Database settings no longer crashes when there is no current database. Both the upload and download handlers now show the existing "remote unavailable" toast instead of throwing.

## Why this matters

`SyncPreferenceFragment.initializePreferences()` read `getDatabases().getCurrent()` and dereferenced it without a null check. When no current database is configured, `getCurrent()` returns null, so `currentDb.isRemoteFileChanged(getContext())` threw a NullPointerException and crashed the app (issue #2978). The download handler had the same unguarded pattern with `isLocalFileChanged()`.

## Changes

Added a `currentDb == null` guard at the top of both the download and upload `onPreferenceClickListener` lambdas. When the current database is null, the handler shows `R.string.remote_unavailable` and returns false, matching the toast already used elsewhere in the same method. Behavior is unchanged when a current database exists.

## Testing

Verified by code review and `git diff --check` (no whitespace errors). A full Android Gradle build was not run; verification was by reading the diff, not a build. The change is a two-line null guard in each of two handlers and introduces no new symbols.

Fixes #2978
