### PR TITLE
Show account name in transaction list item

### DIFF
--- a/app/src/main/java/com/money/manager/ex/adapter/AllDataAdapter.java
+++ b/app/src/main/java/com/money/manager/ex/adapter/AllDataAdapter.java
@@ -119,6 +119,7 @@ public class AllDataAdapter
         holder.txtAmount = view.findViewById(R.id.textViewAmount);
         holder.txtPayee = view.findViewById(R.id.textViewPayee);
         holder.txtAccountName = view.findViewById(R.id.textViewAccountName);
+        holder.txtTransactionAccountName = view.findViewById(R.id.textViewTransactionAccountName);
         holder.txtCategorySub = view.findViewById(R.id.textViewCategorySub);
         holder.txtNotes = view.findViewById(R.id.textViewNotes);
         holder.txtBalance = view.findViewById(R.id.textViewBalance);
@@ -238,6 +239,13 @@ public class AllDataAdapter
             }
         } else {
             holder.txtAccountName.setVisibility(View.GONE);
+        }
+
+        if (!isShowAccountName() && mAccountId == Constants.NOT_SET) {
+            holder.txtTransactionAccountName.setText(cursor.getString(cursor.getColumnIndexOrThrow(ACCOUNTNAME)));
+            holder.txtTransactionAccountName.setVisibility(View.VISIBLE);
+        } else {
+            holder.txtTransactionAccountName.setVisibility(View.GONE);
         }
 
         // Payee

--- a/app/src/main/java/com/money/manager/ex/adapter/AllDataViewHolder.java
+++ b/app/src/main/java/com/money/manager/ex/adapter/AllDataViewHolder.java
@@ -33,6 +33,7 @@ public class AllDataViewHolder {
     public TextView txtAmount;
     public TextView txtPayee;
     public TextView txtAccountName;
+    public TextView txtTransactionAccountName;
     public TextView txtCategorySub;
     public TextView txtNotes;
     public TextView txtBalance;

--- a/app/src/main/res/layout/item_alldata_account.xml
+++ b/app/src/main/res/layout/item_alldata_account.xml
@@ -180,7 +180,7 @@
 
             <com.money.manager.ex.view.RobotoTextView
                 android:id="@+id/textViewTransactionAccountName"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical|end"
                 android:ellipsize="end"
@@ -201,7 +201,7 @@
 
             <com.money.manager.ex.view.RobotoTextView
                 android:id="@+id/textViewStatus"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical|end"
                 android:ellipsize="end"

--- a/app/src/main/res/layout/item_alldata_account.xml
+++ b/app/src/main/res/layout/item_alldata_account.xml
@@ -107,6 +107,17 @@
                 android:singleLine="true" />
 
             <com.money.manager.ex.view.RobotoTextView
+                android:id="@+id/textViewTransactionAccountName"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ellipsize="end"
+                android:singleLine="true"
+                android:textSize="@dimen/mmx_text_view_size_micro"
+                android:textStyle="italic"
+                android:visibility="gone"
+                app:typeface="roboto_condensed_italic" />
+
+            <com.money.manager.ex.view.RobotoTextView
                 android:id="@+id/textViewCategorySub"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"

--- a/app/src/main/res/layout/item_alldata_account.xml
+++ b/app/src/main/res/layout/item_alldata_account.xml
@@ -107,17 +107,6 @@
                 android:singleLine="true" />
 
             <com.money.manager.ex.view.RobotoTextView
-                android:id="@+id/textViewTransactionAccountName"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:ellipsize="end"
-                android:singleLine="true"
-                android:textSize="@dimen/mmx_text_view_size_micro"
-                android:textStyle="italic"
-                android:visibility="gone"
-                app:typeface="roboto_condensed_italic" />
-
-            <com.money.manager.ex.view.RobotoTextView
                 android:id="@+id/textViewCategorySub"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
@@ -190,6 +179,27 @@
             android:orientation="vertical">
 
             <com.money.manager.ex.view.RobotoTextView
+                android:id="@+id/textViewTransactionAccountName"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical|end"
+                android:ellipsize="end"
+                android:gravity="center_vertical|end"
+                android:singleLine="true"
+                android:textSize="@dimen/mmx_text_view_size_micro"
+                android:textStyle="italic"
+                android:visibility="gone"
+                app:typeface="roboto_condensed_italic" />
+
+            <com.money.manager.ex.view.RobotoTextView
+                android:id="@+id/textViewAmount"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical|end"
+                android:gravity="end"
+                android:textStyle="bold" />
+
+            <com.money.manager.ex.view.RobotoTextView
                 android:id="@+id/textViewStatus"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -200,14 +210,6 @@
                 android:textSize="@dimen/mmx_text_view_size_micro"
                 android:textStyle="italic"
                 app:typeface="roboto_condensed_italic" />
-
-            <com.money.manager.ex.view.RobotoTextView
-                android:id="@+id/textViewAmount"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical|end"
-                android:gravity="end"
-                android:textStyle="bold" />
 
             <!-- balance -->
             <com.money.manager.ex.view.RobotoTextView


### PR DESCRIPTION
When transactions are not grouped, the items do not show which account the transaction was done from.
Add a fix to properly show transaction account near the transaction amount.