### PR TITLE
Make `formatNumber` static to fix tests

### DIFF
--- a/app/src/main/java/com/money/manager/ex/common/AmountInputDialog.java
+++ b/app/src/main/java/com/money/manager/ex/common/AmountInputDialog.java
@@ -466,7 +466,7 @@ public class AmountInputDialog
 
             } else {
                 // Use default precision and no currency markup.
-                result = formatUtilities.formatNumber(amount, Constants.DEFAULT_PRECISION,
+                result = FormatUtilities.formatNumber(amount, Constants.DEFAULT_PRECISION,
                     displayCurrency.getDecimalSeparator(), displayCurrency.getGroupSeparator(),
                     null, null);
             }

--- a/app/src/main/java/com/money/manager/ex/common/CalculatorActivity.java
+++ b/app/src/main/java/com/money/manager/ex/common/CalculatorActivity.java
@@ -307,7 +307,7 @@ public class CalculatorActivity extends MmxBaseFragmentActivity {
                         formatUtilitiesLazy.get().getDecimalSeparatorForAppLocale(),
                         formatUtilitiesLazy.get().getGroupingSeparatorForAppLocale());
             } else {
-                result = formatUtilitiesLazy.get().formatNumber(amount, Constants.DEFAULT_PRECISION,
+                result = FormatUtilities.formatNumber(amount, Constants.DEFAULT_PRECISION,
                         displayCurrency.getDecimalSeparator(), displayCurrency.getGroupSeparator(),
                         null, null);
             }

--- a/app/src/main/java/com/money/manager/ex/core/FormatUtilities.java
+++ b/app/src/main/java/com/money/manager/ex/core/FormatUtilities.java
@@ -233,7 +233,7 @@ public class FormatUtilities {
      * @param suffix the suffix to attach.
      * @return Number formatted.
      */
-    public String formatNumber(Money amount, int decimals, String decimalSeparator, String groupSeparator,
+    public static String formatNumber(Money amount, int decimals, String decimalSeparator, String groupSeparator,
                                String prefix, String suffix) {
         // Decimals
 
@@ -245,10 +245,10 @@ public class FormatUtilities {
         // Separators
 
         DecimalFormatSymbols formatSymbols = new DecimalFormatSymbols(Locale.ROOT);
-        if (!(TextUtils.isEmpty(decimalSeparator))) {
+        if (decimalSeparator != null && !decimalSeparator.isEmpty()) {
             formatSymbols.setDecimalSeparator(decimalSeparator.charAt(0));
         }
-        if (!(TextUtils.isEmpty(groupSeparator))) {
+        if (groupSeparator != null && !groupSeparator.isEmpty()) {
             formatSymbols.setGroupingSeparator(groupSeparator.charAt(0));
         }
         // Group size
@@ -291,7 +291,7 @@ public class FormatUtilities {
 
         // group & decimal symbols
         // currency symbol
-        return this.formatNumber(amount, scale, currency.getDecimalSeparator(),
+        return formatNumber(amount, scale, currency.getDecimalSeparator(),
             currency.getGroupSeparator(), currency.getPfxSymbol(), currency.getSfxSymbol());
     }
 

--- a/app/src/test/java/org/moneymanagerex/android/tests/FormatUtilitiesTest.java
+++ b/app/src/test/java/org/moneymanagerex/android/tests/FormatUtilitiesTest.java
@@ -16,16 +16,11 @@
  */
 package org.moneymanagerex.android.tests;
 
-import android.content.Context;
-
 import com.money.manager.ex.core.FormatUtilities;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 
 import java.util.Locale;
 
@@ -38,24 +33,22 @@ import static org.junit.Assert.assertEquals;
  * and does not leak the system/default-locale separators.
  *
  * Regression test for issue #2764.
+ *
+ * {@link FormatUtilities#formatNumber} is a pure function with no instance/DB dependencies,
+ * so the test calls it statically and needs no Robolectric/Context setup.
  */
-@RunWith(RobolectricTestRunner.class)
 public class FormatUtilitiesTest {
 
-    private FormatUtilities formatUtilities;
     private Locale originalLocale;
 
     @Before
     public void setUp() {
-        Context context = RuntimeEnvironment.application.getApplicationContext();
-        formatUtilities = new FormatUtilities(context);
         originalLocale = Locale.getDefault();
     }
 
     @After
     public void tearDown() {
         Locale.setDefault(originalLocale);
-        formatUtilities = null;
     }
 
     /**
@@ -63,7 +56,7 @@ public class FormatUtilitiesTest {
      */
     @Test
     public void formatNumberUsesSuppliedSeparators() {
-        String result = formatUtilities.formatNumber(
+        String result = FormatUtilities.formatNumber(
             MoneyFactory.fromString("1234.56"), 2, ",", ".", null, null);
 
         assertEquals("1.234,56", result);
@@ -76,15 +69,15 @@ public class FormatUtilitiesTest {
     @Test
     public void formatNumberIsIndependentOfDefaultLocale() {
         Locale.setDefault(Locale.US);
-        String inUs = formatUtilities.formatNumber(
+        String inUs = FormatUtilities.formatNumber(
             MoneyFactory.fromString("1234.56"), 2, ",", ".", null, null);
 
         Locale.setDefault(Locale.GERMANY);
-        String inGermany = formatUtilities.formatNumber(
+        String inGermany = FormatUtilities.formatNumber(
             MoneyFactory.fromString("1234.56"), 2, ",", ".", null, null);
 
         Locale.setDefault(new Locale("ar", "EG"));
-        String inEgypt = formatUtilities.formatNumber(
+        String inEgypt = FormatUtilities.formatNumber(
             MoneyFactory.fromString("1234.56"), 2, ",", ".", null, null);
 
         assertEquals(inUs, inGermany);
@@ -100,7 +93,7 @@ public class FormatUtilitiesTest {
     public void formatNumberWithEmptySeparatorsUsesLocaleRootDefaults() {
         Locale.setDefault(Locale.GERMANY);
 
-        String result = formatUtilities.formatNumber(
+        String result = FormatUtilities.formatNumber(
             MoneyFactory.fromString("1234.5"), 2, "", "", null, null);
 
         assertEquals("1,234.50", result);


### PR DESCRIPTION
The tests introduced in #2969 are failing. This PR should fix them I verified locally with `./gradlew test` that tests pass again.