### PR TITLE
fix: use concrete MIME type so Google Drive appears in export/backup picker

### DIFF
--- a/app/src/main/java/com/money/manager/ex/core/docstorage/FileStorageHelper.java
+++ b/app/src/main/java/com/money/manager/ex/core/docstorage/FileStorageHelper.java
@@ -39,7 +39,7 @@ import timber.log.Timber;
  * Functions to assist with selecting database file.
  */
 public class FileStorageHelper {
-    private static final String DATABASE_MIME_TYPE = "application/octet-stream";
+    public static final String DATABASE_MIME_TYPE = "application/octet-stream";
 
     private final Context _host;
 

--- a/app/src/main/java/com/money/manager/ex/core/docstorage/FileStorageHelper.java
+++ b/app/src/main/java/com/money/manager/ex/core/docstorage/FileStorageHelper.java
@@ -39,6 +39,8 @@ import timber.log.Timber;
  * Functions to assist with selecting database file.
  */
 public class FileStorageHelper {
+    private static final String DATABASE_MIME_TYPE = "application/octet-stream";
+
     private final Context _host;
 
     public FileStorageHelper(Context host) {
@@ -74,16 +76,22 @@ public class FileStorageHelper {
         int requestCode = RequestCodes.CREATE_DOCUMENT;
         AppCompatActivity host = (AppCompatActivity) _host;
         try {
-            Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
-            intent.addCategory(Intent.CATEGORY_OPENABLE);
-            intent.setType("*/*");
-            // set default file name as your_data_<creationDateAndTime>.mmb
-            String creationDateAndTime = new MmxDate().toString("yyyyMMdd_HHmmss");
-            intent.putExtra(Intent.EXTRA_TITLE, "your_data_" + creationDateAndTime + ".mmb");
+            Intent intent = buildCreateFileIntent();
             host.startActivityForResult(intent, requestCode);
         } catch (ActivityNotFoundException e) {
             Timber.e(e, "No storage providers found.");
         }
+    }
+
+    static Intent buildCreateFileIntent() {
+        Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.setType(DATABASE_MIME_TYPE);
+        // set default file name as your_data_<creationDateAndTime>.mmb
+        String creationDateAndTime = new MmxDate().toString("yyyyMMdd_HHmmss");
+        intent.putExtra(Intent.EXTRA_TITLE, "your_data_" + creationDateAndTime + ".mmb");
+
+        return intent;
     }
 
     /**

--- a/app/src/main/java/com/money/manager/ex/core/docstorage/FileStorageHelper.java
+++ b/app/src/main/java/com/money/manager/ex/core/docstorage/FileStorageHelper.java
@@ -39,6 +39,8 @@ import timber.log.Timber;
  * Functions to assist with selecting database file.
  */
 public class FileStorageHelper {
+
+    // TODO: evaluate usage of application/x-sqlite3
     public static final String DATABASE_MIME_TYPE = "application/octet-stream";
 
     private final Context _host;

--- a/app/src/main/java/com/money/manager/ex/settings/DatabaseSettingsFragment.java
+++ b/app/src/main/java/com/money/manager/ex/settings/DatabaseSettingsFragment.java
@@ -32,6 +32,7 @@ import com.money.manager.ex.BuildConfig;
 import com.money.manager.ex.MmexApplication;
 import com.money.manager.ex.R;
 import com.money.manager.ex.core.UIHelper;
+import com.money.manager.ex.core.docstorage.FileStorageHelper;
 import com.money.manager.ex.database.MmxOpenHelper;
 import com.money.manager.ex.home.DatabaseMetadata;
 import com.money.manager.ex.home.RecentDatabasesProvider;
@@ -53,7 +54,6 @@ import timber.log.Timber;
 public class DatabaseSettingsFragment
     extends PreferenceFragmentCompat {
 
-    private static final String DATABASE_MIME_TYPE = "application/octet-stream";
     private static final String DEFAULT_BACKUP_FILE_NAME = "your_export_db.mmb";
 
     @Inject Lazy<MmxOpenHelper> openHelper;
@@ -241,7 +241,7 @@ public class DatabaseSettingsFragment
     static Intent buildBackupIntent() {
         Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
         intent.addCategory(Intent.CATEGORY_OPENABLE);
-        intent.setType(DATABASE_MIME_TYPE);
+        intent.setType(FileStorageHelper.DATABASE_MIME_TYPE);
         intent.putExtra(Intent.EXTRA_TITLE, DEFAULT_BACKUP_FILE_NAME); // Set a default file name
 
         return intent;

--- a/app/src/main/java/com/money/manager/ex/settings/DatabaseSettingsFragment.java
+++ b/app/src/main/java/com/money/manager/ex/settings/DatabaseSettingsFragment.java
@@ -53,6 +53,9 @@ import timber.log.Timber;
 public class DatabaseSettingsFragment
     extends PreferenceFragmentCompat {
 
+    private static final String DATABASE_MIME_TYPE = "application/octet-stream";
+    private static final String DEFAULT_BACKUP_FILE_NAME = "your_export_db.mmb";
+
     @Inject Lazy<MmxOpenHelper> openHelper;
     @Inject Lazy<RecentDatabasesProvider> mDatabases;
 
@@ -229,13 +232,19 @@ public class DatabaseSettingsFragment
                     });
 
     private void requestBackup() {
-        Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
-        intent.addCategory(Intent.CATEGORY_OPENABLE);
-        intent.setType("*/*");
-        intent.putExtra(Intent.EXTRA_TITLE, "your_export_db.mmb"); // Set a default file name
+        Intent intent = buildBackupIntent();
 
 //        startActivityForResult(intent, RequestCodes.CODE_BACKUP);
         backupLauncher.launch(intent);
+    }
+
+    static Intent buildBackupIntent() {
+        Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.setType(DATABASE_MIME_TYPE);
+        intent.putExtra(Intent.EXTRA_TITLE, DEFAULT_BACKUP_FILE_NAME); // Set a default file name
+
+        return intent;
     }
 
 /* Relpace with backupLauncher

--- a/app/src/test/java/org/moneymanagerex/android/tests/ExportIntentTests.java
+++ b/app/src/test/java/org/moneymanagerex/android/tests/ExportIntentTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2012-2018 The Android Money Manager Ex Project Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.moneymanagerex.android.tests;
+
+import android.content.Intent;
+
+import com.money.manager.ex.core.docstorage.FileStorageHelper;
+import com.money.manager.ex.settings.DatabaseSettingsFragment;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(RobolectricTestRunner.class)
+public class ExportIntentTests {
+    private static final String DATABASE_MIME_TYPE = "application/octet-stream";
+
+    @Test
+    public void databaseSettingsBackupIntentUsesConcreteMimeType() throws Exception {
+        Intent intent = invokeIntentBuilder(DatabaseSettingsFragment.class, "buildBackupIntent");
+
+        assertCreateDocumentIntent(intent);
+        assertEquals("your_export_db.mmb", intent.getStringExtra(Intent.EXTRA_TITLE));
+        assertTrue(intent.getStringExtra(Intent.EXTRA_TITLE).endsWith(".mmb"));
+    }
+
+    @Test
+    public void fileStorageCreateIntentUsesTimestampedMmbTitle() throws Exception {
+        Intent intent = invokeIntentBuilder(FileStorageHelper.class, "buildCreateFileIntent");
+
+        assertCreateDocumentIntent(intent);
+        assertTrue(intent.getStringExtra(Intent.EXTRA_TITLE).matches("your_data_\\d{8}_\\d{6}\\.mmb"));
+    }
+
+    private static void assertCreateDocumentIntent(Intent intent) {
+        assertEquals(Intent.ACTION_CREATE_DOCUMENT, intent.getAction());
+        assertTrue(intent.hasCategory(Intent.CATEGORY_OPENABLE));
+        assertEquals(DATABASE_MIME_TYPE, intent.getType());
+        assertNotEquals("*/*", intent.getType());
+    }
+
+    private static Intent invokeIntentBuilder(Class<?> targetClass, String methodName) throws Exception {
+        Method method = targetClass.getDeclaredMethod(methodName);
+        method.setAccessible(true);
+
+        return (Intent) method.invoke(null);
+    }
+}

--- a/app/src/test/java/org/moneymanagerex/android/tests/ExportIntentTests.java
+++ b/app/src/test/java/org/moneymanagerex/android/tests/ExportIntentTests.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 public class ExportIntentTests {
-    private static final String DATABASE_MIME_TYPE = "application/octet-stream";
+    private static final String DATABASE_MIME_TYPE = FileStorageHelper.DATABASE_MIME_TYPE;
 
     @Test
     public void databaseSettingsBackupIntentUsesConcreteMimeType() throws Exception {


### PR DESCRIPTION
## Summary

Uses a concrete MIME type when launching the "create document" picker for database export/backup, so Google Drive (and other providers that filter by MIME type) appear as destinations. Previously the intent used a generic/wildcard type that Drive does not advertise support for, so it was hidden from the picker.

## Why this matters

Issue #2950 reports that Google Drive does not show up when exporting or backing up the database: the system document picker only lists providers that claim to handle the requested MIME type, and the generic type used before did not match Drive's declared filters. Users could not pick Drive as an export target at all.

This sets a concrete MIME type on the `ACTION_CREATE_DOCUMENT` intents built in `FileStorageHelper` and `DatabaseSettingsFragment`, matching the actual file being written, so Drive and similar providers appear. The rest of the create-document behavior is unchanged.

## Testing

Added `ExportIntentTests` covering the intent builders: the export/backup intents now carry the concrete MIME type and the `CREATE_DOCUMENT` action and title extras are preserved. On-device flow was not exercised in this environment; the change is limited to the intent's MIME type and is covered by the new unit tests.

Fixes #2950
