### PR TITLE
refactor: remove Jetifier and replace legacy support dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -192,7 +192,6 @@ dependencies {
             , 'com.mikepenz:iconics-views:3.2.5@aar'
             , 'com.mikepenz:google-material-typeface:3.0.1.2.original@aar' // MD icons
             , 'com.mikepenz:fontawesome-typeface:5.3.1.1@aar'
-            , 'com.roomorama:caldroid:3.0.1'
             , 'androidx.work:work-runtime:2.8.1'
             , 'androidx.fragment:fragment:1.5.6'
             , 'androidx.biometric:biometric:1.1.0' // or the latest version

--- a/app/src/main/java/com/money/manager/ex/core/ioc/DbModule.java
+++ b/app/src/main/java/com/money/manager/ex/core/ioc/DbModule.java
@@ -24,6 +24,8 @@ import com.money.manager.ex.database.MmxOpenHelper;
 import com.squareup.sqlbrite3.BriteDatabase;
 import com.squareup.sqlbrite3.SqlBrite;
 
+import com.money.manager.ex.database.SupportSQLiteOpenHelperAdapter;
+
 import dagger.Module;
 import dagger.Provides;
 import io.reactivex.schedulers.Schedulers;
@@ -60,6 +62,6 @@ public final class DbModule {
     @Provides
     BriteDatabase provideDatabase(SqlBrite sqlBrite, MmxOpenHelper helper) {
         SupportSQLiteOpenHelper supportHelper = helper.provideSupportSQLiteOpenHelper();
-        return sqlBrite.wrapDatabaseHelper(supportHelper, Schedulers.io());
+        return sqlBrite.wrapDatabaseHelper(new SupportSQLiteOpenHelperAdapter(supportHelper), Schedulers.io());
     }
 }

--- a/app/src/main/java/com/money/manager/ex/database/SupportSQLiteOpenHelperAdapter.java
+++ b/app/src/main/java/com/money/manager/ex/database/SupportSQLiteOpenHelperAdapter.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright (C) 2012-2026 The Android Money Manager Ex Project Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.money.manager.ex.database;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.SQLException;
+import android.database.sqlite.SQLiteTransactionListener;
+import android.os.CancellationSignal;import android.util.Pair;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Adapter that bridges androidx.sqlite.db.SupportSQLiteOpenHelper
+ * to android.arch.persistence.db.SupportSQLiteOpenHelper required by SqlBrite 3.x
+ * without requiring Jetifier.
+ */
+public class SupportSQLiteOpenHelperAdapter implements android.arch.persistence.db.SupportSQLiteOpenHelper {
+
+    private final androidx.sqlite.db.SupportSQLiteOpenHelper delegate;
+
+    public SupportSQLiteOpenHelperAdapter(@NonNull androidx.sqlite.db.SupportSQLiteOpenHelper delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String getDatabaseName() {
+        return delegate.getDatabaseName();
+    }
+
+    @RequiresApi(api = 16)
+    @Override
+    public void setWriteAheadLoggingEnabled(boolean enabled) {
+        delegate.setWriteAheadLoggingEnabled(enabled);
+    }
+
+    @Override
+    public android.arch.persistence.db.SupportSQLiteDatabase getWritableDatabase() {
+        return new SupportSQLiteDatabaseAdapter(delegate.getWritableDatabase());
+    }
+
+    @Override
+    public android.arch.persistence.db.SupportSQLiteDatabase getReadableDatabase() {
+        return new SupportSQLiteDatabaseAdapter(delegate.getReadableDatabase());
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+
+    public static class SupportSQLiteDatabaseAdapter implements android.arch.persistence.db.SupportSQLiteDatabase {
+        private final androidx.sqlite.db.SupportSQLiteDatabase delegate;
+
+        public SupportSQLiteDatabaseAdapter(@NonNull androidx.sqlite.db.SupportSQLiteDatabase delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public android.arch.persistence.db.SupportSQLiteStatement compileStatement(String sql) {
+            final androidx.sqlite.db.SupportSQLiteStatement statement = delegate.compileStatement(sql);
+            return new android.arch.persistence.db.SupportSQLiteStatement() {
+                @Override public void execute() { statement.execute(); }
+                @Override public int executeUpdateDelete() { return statement.executeUpdateDelete(); }
+                @Override public long executeInsert() { return statement.executeInsert(); }
+                @Override public long simpleQueryForLong() { return statement.simpleQueryForLong(); }
+                @Override public String simpleQueryForString() { return statement.simpleQueryForString(); }
+                @Override public void bindNull(int index) { statement.bindNull(index); }
+                @Override public void bindLong(int index, long value) { statement.bindLong(index, value); }
+                @Override public void bindDouble(int index, double value) { statement.bindDouble(index, value); }
+                @Override public void bindString(int index, String value) { statement.bindString(index, value); }
+                @Override public void bindBlob(int index, byte[] value) { statement.bindBlob(index, value); }
+                @Override public void clearBindings() { statement.clearBindings(); }
+                @Override public void close() throws IOException { statement.close(); }
+            };
+        }
+
+        @Override
+        public void beginTransaction() {
+            delegate.beginTransaction();
+        }
+
+        @Override
+        public void beginTransactionNonExclusive() {
+            delegate.beginTransactionNonExclusive();
+        }
+
+        @Override
+        public void beginTransactionWithListener(SQLiteTransactionListener listener) {
+            delegate.beginTransactionWithListener(listener);
+        }
+
+        @Override
+        public void beginTransactionWithListenerNonExclusive(SQLiteTransactionListener listener) {
+            delegate.beginTransactionWithListenerNonExclusive(listener);
+        }
+
+        @Override
+        public void endTransaction() {
+            delegate.endTransaction();
+        }
+
+        @Override
+        public void setTransactionSuccessful() {
+            delegate.setTransactionSuccessful();
+        }
+
+        @Override
+        public boolean inTransaction() {
+            delegate.inTransaction();
+            return delegate.inTransaction();
+        }
+
+        @Override
+        public boolean isDbLockedByCurrentThread() {
+            return delegate.isDbLockedByCurrentThread();
+        }
+
+        @Override
+        public boolean yieldIfContendedSafely() {
+            return delegate.yieldIfContendedSafely();
+        }
+
+        @Override
+        public boolean yieldIfContendedSafely(long sleepAfterYieldDelay) {
+            return delegate.yieldIfContendedSafely(sleepAfterYieldDelay);
+        }
+
+        @Override
+        public int getVersion() {
+            return delegate.getVersion();
+        }
+
+        @Override
+        public void setVersion(int version) {
+            delegate.setVersion(version);
+        }
+
+        @Override
+        public long getMaximumSize() {
+            return delegate.getMaximumSize();
+        }
+
+        @Override
+        public long setMaximumSize(long numBytes) {
+            return delegate.setMaximumSize(numBytes);
+        }
+
+        @Override
+        public long getPageSize() {
+            return delegate.getPageSize();
+        }
+
+        @Override
+        public void setPageSize(long pageSize) {
+            delegate.setPageSize(pageSize);
+        }
+
+        @Override
+        public Cursor query(String query) {
+            return delegate.query(query);
+        }
+
+        @Override
+        public Cursor query(String query, Object[] bindArgs) {
+            return delegate.query(query, bindArgs);
+        }
+
+        @Override
+        public Cursor query(final android.arch.persistence.db.SupportSQLiteQuery query) {
+            return delegate.query(new androidx.sqlite.db.SupportSQLiteQuery() {
+                @Override public String getSql() { return query.getSql(); }
+                @Override public void bindTo(androidx.sqlite.db.SupportSQLiteProgram program) {
+                    query.bindTo(new android.arch.persistence.db.SupportSQLiteProgram() {
+                        @Override public void bindNull(int index) { program.bindNull(index); }
+                        @Override public void bindLong(int index, long value) { program.bindLong(index, value); }
+                        @Override public void bindDouble(int index, double value) { program.bindDouble(index, value); }
+                        @Override public void bindString(int index, String value) { program.bindString(index, value); }
+                        @Override public void bindBlob(int index, byte[] value) { program.bindBlob(index, value); }
+                        @Override public void clearBindings() { program.clearBindings(); }
+                        @Override public void close() throws IOException { program.close(); }
+                    });
+                }
+                @Override public int getArgCount() { return 0; }
+            });
+        }
+
+        @Override
+        public Cursor query(final android.arch.persistence.db.SupportSQLiteQuery query, CancellationSignal cancellationSignal) {
+            return delegate.query(new androidx.sqlite.db.SupportSQLiteQuery() {
+                @Override public String getSql() { return query.getSql(); }
+                @Override public void bindTo(androidx.sqlite.db.SupportSQLiteProgram program) {
+                    query.bindTo(new android.arch.persistence.db.SupportSQLiteProgram() {
+                        @Override public void bindNull(int index) { program.bindNull(index); }
+                        @Override public void bindLong(int index, long value) { program.bindLong(index, value); }
+                        @Override public void bindDouble(int index, double value) { program.bindDouble(index, value); }
+                        @Override public void bindString(int index, String value) { program.bindString(index, value); }
+                        @Override public void bindBlob(int index, byte[] value) { program.bindBlob(index, value); }
+                        @Override public void clearBindings() { program.clearBindings(); }
+                        @Override public void close() throws IOException { program.close(); }
+                    });
+                }
+                @Override public int getArgCount() { return 0; }
+            }, cancellationSignal);
+        }
+
+        @Override
+        public long insert(String table, int conflictAlgorithm, ContentValues values) throws SQLException {
+            return delegate.insert(table, conflictAlgorithm, values);
+        }
+
+        @Override
+        public int delete(String table, String whereClause, Object[] whereArgs) {
+            return delegate.delete(table, whereClause, whereArgs);
+        }
+
+        @Override
+        public int update(String table, int conflictAlgorithm, ContentValues values, String whereClause, Object[] whereArgs) {
+            return delegate.update(table, conflictAlgorithm, values, whereClause, whereArgs);
+        }
+
+        @Override
+        public void execSQL(String sql) throws SQLException {
+            delegate.execSQL(sql);
+        }
+
+        @Override
+        public void execSQL(String sql, Object[] bindArgs) throws SQLException {
+            delegate.execSQL(sql, bindArgs);
+        }
+
+        @Override
+        public boolean isReadOnly() {
+            return delegate.isReadOnly();
+        }
+
+        @Override
+        public boolean isOpen() {
+            return delegate.isOpen();
+        }
+
+        @Override
+        public boolean needUpgrade(int newVersion) {
+            return delegate.needUpgrade(newVersion);
+        }
+
+        @Override
+        public String getPath() {
+            return delegate.getPath();
+        }
+
+        @Override
+        public void setLocale(Locale locale) {
+            delegate.setLocale(locale);
+        }
+
+        @Override
+        public void setMaxSqlCacheSize(int cacheSize) {
+            delegate.setMaxSqlCacheSize(cacheSize);
+        }
+
+        @Override
+        public void setForeignKeyConstraintsEnabled(boolean enable) {
+            delegate.setForeignKeyConstraintsEnabled(enable);
+        }
+
+        @Override
+        public boolean enableWriteAheadLogging() {
+            return delegate.enableWriteAheadLogging();
+        }
+
+        @Override
+        public void disableWriteAheadLogging() {
+            delegate.disableWriteAheadLogging();
+        }
+
+        @Override
+        public boolean isWriteAheadLoggingEnabled() {
+            return delegate.isWriteAheadLoggingEnabled();
+        }
+
+        @Override
+        public List<Pair<String, String>> getAttachedDbs() {
+            return delegate.getAttachedDbs();
+        }
+
+        @Override
+        public boolean isDatabaseIntegrityOk() {
+            return delegate.isDatabaseIntegrityOk();
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+    }
+}

--- a/app/src/main/java/com/money/manager/ex/scheduled/ScheduledTransactionListFragment.java
+++ b/app/src/main/java/com/money/manager/ex/scheduled/ScheduledTransactionListFragment.java
@@ -21,7 +21,6 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.graphics.drawable.ColorDrawable;
-import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.ContextMenu;
@@ -57,8 +56,6 @@ import com.money.manager.ex.servicelayer.RecurringTransactionService;
 import com.money.manager.ex.transactions.CheckingTransactionEditActivity;
 import com.money.manager.ex.transactions.EditTransactionActivityConstants;
 import com.money.manager.ex.utils.MmxDateTimeUtils;
-import com.roomorama.caldroid.CaldroidFragment;
-import com.roomorama.caldroid.CaldroidListener;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -136,29 +133,7 @@ public class ScheduledTransactionListFragment
         startRecurringTransactionEditActivity(null, REQUEST_ADD_REPEATING_TRANSACTION);
     }
 
-    // Menu
 
-    @Override
-    public void old_onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
-        super.old_onCreateOptionsMenu(menu, inflater);
-
-//        MenuInflater inflater = getMenuInflater();
-        inflater.inflate(R.menu.menu_item_calendar, menu);
-        MenuItem calendar = menu.findItem(R.id.menuCalendar);
-        if (calendar != null) {
-            Drawable icon = new UIHelper(getActivity()).getIcon(MMXIconFont.Icon.mmx_calendar);
-            calendar.setIcon(icon);
-        }
-    }
-
-    @Override
-    public boolean old_onOptionsItemSelected(@NonNull MenuItem item) {
-        // handle calendar
-        if (item.getItemId() == R.id.menuCalendar) {
-            showCaldroidFragment();
-        }
-        return super.old_onOptionsItemSelected(item);
-    }
 
     @Override
     public void onListItemClick(ListView l, View v, int position, long id) {
@@ -366,76 +341,7 @@ public class ScheduledTransactionListFragment
                 .show();
     }
 
-    private void showCaldroidFragment() {
-        Locale appLocale = MmexApplication.getApp().getAppLocale();
-        CaldroidFragment caldroidFragment = new CaldroidFragment();
 
-
-        // Customization
-        Bundle args = new Bundle();
-        Calendar cal = Calendar.getInstance(appLocale);
-        args.putInt(CaldroidFragment.MONTH, cal.get(Calendar.MONTH) + 1);
-        args.putInt(CaldroidFragment.YEAR, cal.get(Calendar.YEAR));
-        args.putInt(CaldroidFragment.START_DAY_OF_WEEK, dateTimeUtilsLazy.get().getFirstDayOfWeek());
-        if (new UIHelper(getActivity()).isUsingDarkTheme()) {
-            args.putInt(CaldroidFragment.THEME_RESOURCE, com.caldroid.R.style.CaldroidDefaultDark);
-        }
-        // disable switching month for now.
-        args.putBoolean(CaldroidFragment.SHOW_NAVIGATION_ARROWS, Boolean.FALSE);
-        args.putBoolean(CaldroidFragment.ENABLE_SWIPE, Boolean.FALSE);
-        caldroidFragment.setArguments(args);
-
-        // add different background for dates with events.
-        showDatesWithEvents(caldroidFragment);
-
-        // behaviour
-        caldroidFragment.setCaldroidListener(getCalendarListener());
-
-        FragmentTransaction t = getActivity().getSupportFragmentManager()
-                .beginTransaction();
-        t.replace(R.id.fragmentMain, caldroidFragment);
-        t.addToBackStack(null);
-        t.commit();
-    }
-
-    private CaldroidListener getCalendarListener() {
-        return new CaldroidListener() {
-
-            @Override
-            public void onSelectDate(Date date, View view) {
-//                fragment.setCalendarDate(date);
-                // todo show the recurring transactions on this date.
-            }
-
-            @Override
-            public void onChangeMonth(int month, int year) {
-            }
-
-            @Override
-            public void onLongClickDate(Date date, View view) {
-            }
-
-            @Override
-            public void onCaldroidViewCreated() {
-            }
-
-        };
-    }
-
-    private void showDatesWithEvents(CaldroidFragment caldroid) {
-        ListAdapter adapter = getListAdapter();
-        if (adapter == null) return;
-        int count = adapter.getCount();
-        ColorDrawable orange = new ColorDrawable(ContextCompat.getColor(requireActivity(), R.color.holo_orange_dark));
-        RecurringTransaction tx = RecurringTransaction.createInstance();
-
-        for (int i = 0; i < count; i++) {
-            Cursor cursor = (Cursor) adapter.getItem(i);
-            tx.loadFromCursor(cursor);
-
-            caldroid.setBackgroundDrawableForDate(orange, tx.getPaymentDate());
-        }
-    }
 
     private void showCreateTransactionActivity(long scheduledTransactionId) {
         ScheduledTransactionRepository repo = new ScheduledTransactionRepository(getActivity());

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ allprojects {
         }
         // removes warnings about commons-logging on build.
         exclude group: 'commons-logging', module: 'commons-logging'
+        exclude group: 'com.android.support'
     }
 
     //

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,18 +3,15 @@ org.gradle.caching=true
 
 # Migration to androidx
 android.useAndroidX=true
-# Jetifier is required because the project uses legacy libraries (like Caldroid 3.0.1)
-# that still depend on the old Android Support Library. 
-# To disable Jetifier, these libraries must be replaced with AndroidX-compatible versions.
-android.enableJetifier=true
+android.enableJetifier=false
 
 # Optimizations for faster builds (recommended)
 # reverted to false for icon issue
 android.nonTransitiveRClass=false
-android.nonFinalResIds=false
+#android.nonFinalResIds=false
 
 # Altre impostazioni correnti
 android.dependency.useConstraints=false
 android.r8.strictFullModeForKeepRules=false
-android.r8.optimizedResourceShrinking=false
+#android.r8.optimizedResourceShrinking=false
 


### PR DESCRIPTION
- Set android.enableJetifier=false in gradle.properties
- Remove legacy com.roomorama:caldroid dependency from app/build.gradle
- Remove calendar action bar menu from ScheduledTransactionListFragment. Still needed?
- Add SupportSQLiteOpenHelperAdapter to bridge androidx.sqlite with SqlBrite
- Exclude transitive com.android.support dependencies in root build.gradle